### PR TITLE
add create contract transaction

### DIFF
--- a/src/it/container/start-waves.sh
+++ b/src/it/container/start-waves.sh
@@ -7,4 +7,5 @@ echo Default: $DEFAULT_NET_IP
 echo Waves: $WAVES_NET_IP
 echo Options: $WAVES_OPTS
 
-java -Dwaves.network.declared-address=$WAVES_NET_IP:$WAVES_PORT $WAVES_OPTS -jar /opt/waves/waves.jar /opt/waves/template.conf
+#java -Dwaves.network.declared-address=$WAVES_NET_IP:$WAVES_PORT $WAVES_OPTS -jar /opt/waves/waves.jar /opt/waves/template.conf
+java -Dwaves.network.declared-address=$DEFAULT_NET_IP:6863 $WAVES_OPTS -jar /opt/waves/waves.jar /opt/waves/template.conf

--- a/src/it/resources/template.conf
+++ b/src/it/resources/template.conf
@@ -2,9 +2,10 @@ waves {
   directory = tmp/waves
   logging-level = DEBUG
   network {
+#    known-peers = ["172.17.0.2:6863"]
     known-peers = []
     black-list-residence-time = 30s
-    peers-broadcast-interval = 2s
+    peers-broadcast-interval = 5s
     connection-timeout = 30s
   }
   wallet {
@@ -36,7 +37,7 @@ waves {
       genesis {
         timestamp = 1528036610296763852
         block-timestamp = 1528036610296763852
-        signature = 5JY5NvSfyT3fu2nurcHB5sZojeXY43dT9vxcBbcTMd61T3wYV9e7n74f3Dh8iRL39YB2TfQpvHBqkLJk97TTW69S
+        signature = 1Lmo9uYoqb4rrG7P589qx4Nrso41WZiELRHV7AnoY8jP8qTWRb9zuCYJumqNGTEckRL2E7TJHP2QyWykx7pBnHQ
         initial-balance =  1000000000000000
         initial-base-target = 153722867
         average-block-delay = 60s
@@ -68,7 +69,8 @@ waves {
   rest-api {
     enable = yes
     bind-address = 0.0.0.0
-    api-key-hash = 5yPkqXs6RbAte8GysnqpTudkPhxycZJvteQYuo8vt5Xs
+    #key is wavestest2018 for hash 9t8DxH6z99toHVe5htCH9SvWKbaCh45JbMnF43mDGHnZ
+    api-key-hash = 9t8DxH6z99toHVe5htCH9SvWKbaCh45JbMnF43mDGHnZ
   }
   utx.broadcast-interval = 3s
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -202,6 +202,9 @@ waves {
     minting {
       WAVES = 100000
     }
+    create-contract {
+      WAVES = 200000
+    }
   }
 
   # Matcher settings

--- a/src/main/scala/com/wavesplatform/Application.scala
+++ b/src/main/scala/com/wavesplatform/Application.scala
@@ -28,6 +28,7 @@ import scorex.api.http._
 import scorex.api.http.alias.{AliasApiRoute, AliasBroadcastApiRoute}
 import scorex.api.http.spos.{SPOSApiRoute,SPOSBroadcastApiRoute}
 import scorex.api.http.assets.{AssetsApiRoute, AssetsBroadcastApiRoute}
+import scorex.api.http.contract.{ContractApiRoute, ContractBroadcastApiRoute}
 import scorex.api.http.leasing.{LeaseApiRoute, LeaseBroadcastApiRoute}
 import scorex.block.Block
 import scorex.consensus.nxt.api.http.NxtConsensusApiRoute
@@ -95,7 +96,9 @@ class Application(val actorSystem: ActorSystem, val settings: WavesSettings) ext
       AliasApiRoute(settings.restAPISettings, wallet, utxStorage, allChannels, time, stateReader),
       AliasBroadcastApiRoute(settings.restAPISettings, utxStorage, allChannels),
       SPOSApiRoute(settings.restAPISettings, wallet, utxStorage, allChannels, time, stateReader),
-      SPOSBroadcastApiRoute(settings.restAPISettings, utxStorage, allChannels)
+      SPOSBroadcastApiRoute(settings.restAPISettings, utxStorage, allChannels),
+      ContractApiRoute(settings.restAPISettings, wallet, utxStorage, allChannels, time, stateReader),
+      ContractBroadcastApiRoute(settings.restAPISettings, utxStorage, allChannels)
     )
 
     val apiTypes = Seq(
@@ -117,7 +120,9 @@ class Application(val actorSystem: ActorSystem, val settings: WavesSettings) ext
       typeOf[AliasApiRoute],
       typeOf[AliasBroadcastApiRoute],
       typeOf[SPOSApiRoute],
-      typeOf[SPOSBroadcastApiRoute]
+      typeOf[SPOSBroadcastApiRoute],
+      typeOf[ContractApiRoute],
+      typeOf[ContractBroadcastApiRoute]
     )
 
     for (addr <- settings.networkSettings.declaredAddress if settings.networkSettings.uPnPSettings.enable) {

--- a/src/main/scala/com/wavesplatform/state2/Diff.scala
+++ b/src/main/scala/com/wavesplatform/state2/Diff.scala
@@ -44,6 +44,7 @@ case class Diff(transactions: Map[ByteStr, (Int, Transaction, Set[Address])],
                 issuedAssets: Map[ByteStr, AssetInfo],
                 aliases: Map[Alias, Address],
                 slotids: Map[Int,String],
+                contracts: Map[String, String],
                 paymentTransactionIdsByHashes: Map[ByteStr, ByteStr],
                 orderFills: Map[ByteStr, OrderFillInfo],
                 leaseState: Map[ByteStr, Boolean]) {
@@ -66,6 +67,7 @@ object Diff {
             assetInfos: Map[ByteStr, AssetInfo] = Map.empty,
             aliases: Map[Alias, Address] = Map.empty,
             slotids: Map[Int,String] = Map.empty,
+            contracts: Map[String, String] = Map.empty,
             orderFills: Map[ByteStr, OrderFillInfo] = Map.empty,
             paymentTransactionIdsByHashes: Map[ByteStr, ByteStr] = Map.empty,
             leaseState: Map[ByteStr, Boolean] = Map.empty): Diff = Diff(
@@ -74,11 +76,12 @@ object Diff {
     issuedAssets = assetInfos,
     aliases = aliases,
     slotids = slotids,
+    contracts = contracts,
     paymentTransactionIdsByHashes = paymentTransactionIdsByHashes,
     orderFills = orderFills,
     leaseState = leaseState)
 
-  val empty = new Diff(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty)
+  val empty = new Diff(Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty)
 
   implicit class DiffExt(d: Diff) {
     def asBlockDiff: BlockDiff = BlockDiff(d, 0, Map.empty)
@@ -93,6 +96,7 @@ object Diff {
       issuedAssets = older.issuedAssets.combine(newer.issuedAssets),
       aliases = older.aliases ++ newer.aliases,
       slotids = older.slotids ++ newer.slotids,
+      contracts = older.contracts ++ newer.contracts,
       paymentTransactionIdsByHashes = older.paymentTransactionIdsByHashes ++ newer.paymentTransactionIdsByHashes,
       orderFills = older.orderFills.combine(newer.orderFills),
       leaseState = older.leaseState ++ newer.leaseState)

--- a/src/main/scala/com/wavesplatform/state2/StateStorage.scala
+++ b/src/main/scala/com/wavesplatform/state2/StateStorage.scala
@@ -70,6 +70,8 @@ class StateStorage private(file: Option[File]) extends AutoCloseable {
   val lastBalanceSnapshotHeight: MVMap[ByteStr, Int] = db.openMap("lastUpdateHeight", new LogMVMapBuilder[ByteStr, Int]
     .keyType(DataTypes.byteStr))
 
+  val contracts: MVMap[String, String] = db.openMap("contracts")
+
   def commit(): Unit = {
      db.commit()
     db.compact(CompactFillRate, CompactMemorySize)

--- a/src/main/scala/com/wavesplatform/state2/StateWriter.scala
+++ b/src/main/scala/com/wavesplatform/state2/StateWriter.scala
@@ -100,6 +100,12 @@ class StateWriterImpl(p: StateStorage, synchronizationToken: ReentrantReadWriteL
       }
     }
 
+    measureSizeLog("contract creation")(blockDiff.txsDiff.contracts) {
+      _.foreach { case (name, content) =>
+        sp().contracts.put(name, content)
+      }
+    }
+
     measureSizeLog("lease info")(blockDiff.txsDiff.leaseState)(
       _.foreach { case (id, isActive) => sp().leaseState.put(id, isActive) })
 

--- a/src/main/scala/com/wavesplatform/state2/diffs/CommonValidation.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/CommonValidation.scala
@@ -87,6 +87,7 @@ object CommonValidation {
       case _: CreateAliasTransaction => Right(tx)
       case _: MintingTransaction => Right(tx)
       case _: ContendSlotsTransaction => Right(tx)
+      case _: CreateContractTransaction => Right(tx)
       case _ => Left(GenericError("Unknown transaction must be explicitly registered within ActivatedValidator"))
     }
 

--- a/src/main/scala/com/wavesplatform/state2/diffs/CreateContractTransactionDiff.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/CreateContractTransactionDiff.scala
@@ -1,0 +1,15 @@
+package com.wavesplatform.state2.diffs
+
+import com.wavesplatform.state2.{Diff, LeaseInfo, Portfolio}
+import scorex.transaction.{CreateContractTransaction, ValidationError}
+
+import scala.util.Right
+
+object CreateContractTransactionDiff {
+  def apply(height: Int)(tx: CreateContractTransaction): Either[ValidationError, Diff] = {
+    Right(Diff(height = height, tx = tx,
+      portfolios = Map(tx.sender.toAddress -> Portfolio(-tx.fee, LeaseInfo.empty, Map.empty)),
+      contracts = Map(tx.contract.name -> tx.contract.content)
+    ))
+  }
+}

--- a/src/main/scala/com/wavesplatform/state2/diffs/TransactionDiffer.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/TransactionDiffer.scala
@@ -35,6 +35,7 @@ object TransactionDiffer {
         case atx: CreateAliasTransaction => CreateAliasTransactionDiff(currentBlockHeight)(atx)
         case mtx: MintingTransaction => MintingTransactionDiff(s, currentBlockHeight, settings, currentBlockTimestamp)(mtx)
         case ctx: ContendSlotsTransaction => ContendSlotsTransactionDiff(s,settings,currentBlockHeight)(ctx)
+        case cctx: CreateContractTransaction => CreateContractTransactionDiff(currentBlockHeight)(cctx)
         case _ => Left(UnsupportedTransactionType)
       }
       positiveDiff <- BalanceDiffValidation(s, currentBlockTimestamp, settings)(diff)

--- a/src/main/scala/com/wavesplatform/state2/patch/LeasePatch.scala
+++ b/src/main/scala/com/wavesplatform/state2/patch/LeasePatch.scala
@@ -18,6 +18,7 @@ object LeasePatch {
       issuedAssets = Map.empty,
       aliases = Map.empty,
       slotids = Map.empty,
+      contracts = Map.empty,
       paymentTransactionIdsByHashes = Map.empty,
       orderFills = Map.empty,
       leaseState = s.activeLeases().map(_ -> false).toMap)

--- a/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/CompositeStateReader.scala
@@ -55,6 +55,8 @@ class CompositeStateReader(inner: StateReader, blockDiff: BlockDiff) extends Sta
 
   override def resolveAlias(a: Alias): Option[Address] = txDiff.aliases.get(a).orElse(inner.resolveAlias(a))
 
+  override def contractContent(name: String): Option[String] = txDiff.contracts.get(name).orElse(inner.contractContent(name))
+
   override def accountPortfolios: Map[Address, Portfolio] = Monoid.combine(inner.accountPortfolios, txDiff.portfolios)
 
   override def isLeaseActive(leaseTx: LeaseTransaction): Boolean =
@@ -98,6 +100,9 @@ object CompositeStateReader {
 
     override def resolveAlias(a: Alias): Option[Address] =
       new CompositeStateReader(inner, blockDiff()).resolveAlias(a)
+
+    override def contractContent(name: String): Option[String] =
+      new CompositeStateReader(inner, blockDiff()).contractContent(name)
 
     override def assetInfo(id: ByteStr): Option[AssetInfo] =
       new CompositeStateReader(inner, blockDiff()).assetInfo(id)

--- a/src/main/scala/com/wavesplatform/state2/reader/StateReader.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/StateReader.scala
@@ -37,6 +37,8 @@ trait StateReader extends Synchronized {
 
   def resolveAlias(a: Alias): Option[Address]
 
+  def contractContent(name: String): Option[String]
+
   def isLeaseActive(leaseTx: LeaseTransaction): Boolean
 
   def activeLeases(): Seq[ByteStr]

--- a/src/main/scala/com/wavesplatform/state2/reader/StateReaderImpl.scala
+++ b/src/main/scala/com/wavesplatform/state2/reader/StateReaderImpl.scala
@@ -57,6 +57,10 @@ class StateReaderImpl(p: StateStorage, val synchronizationToken: ReentrantReadWr
       .map(b => Address.fromBytes(b.arr).explicitGet())
   }
 
+  override def contractContent(name: String): Option[String] = read { implicit l =>
+    Option(sp().contracts.get(name))
+  }
+
   override def accountPortfolios: Map[Address, Portfolio] = read { implicit l =>
     sp().portfolios.asScala.map {
       case (acc, (b, (i, o), as)) => Address.fromBytes(acc.arr).explicitGet() -> Portfolio(b, LeaseInfo(i, o), as.map {

--- a/src/main/scala/scorex/api/http/ApiError.scala
+++ b/src/main/scala/scorex/api/http/ApiError.scala
@@ -194,6 +194,12 @@ case class AliasNotExists(aoa: AddressOrAlias) extends ApiError {
   override val message: String = s"alias $msgReason doesn't exist"
 }
 
+case class ContractNotExists(name: String) extends ApiError {
+  override val id: Int = 302
+  override val code = StatusCodes.NotFound
+  override val message: String = s"contract $name doesn't exist"
+}
+
 case class Mistiming(errorMessage: String) extends ApiError {
   override val id: Int = Mistiming.Id
   override val message: String = errorMessage

--- a/src/main/scala/scorex/api/http/contract/ContractApiRoute.scala
+++ b/src/main/scala/scorex/api/http/contract/ContractApiRoute.scala
@@ -1,0 +1,55 @@
+package scorex.api.http.contract
+
+import javax.ws.rs.Path
+import akka.http.scaladsl.server.Route
+import com.wavesplatform.UtxPool
+import com.wavesplatform.settings.RestAPISettings
+import com.wavesplatform.state2.reader.StateReader
+import io.netty.channel.group.ChannelGroup
+import io.swagger.annotations._
+import play.api.libs.json.Json
+import scorex.BroadcastRoute
+import scorex.api.http._
+import scorex.transaction._
+import scorex.utils.Time
+import scorex.wallet.Wallet
+
+@Path("/contract")
+@Api(value = "/contract")
+case class ContractApiRoute (settings: RestAPISettings, wallet: Wallet, utx: UtxPool, allChannels: ChannelGroup, time: Time, state: StateReader)
+  extends ApiRoute with BroadcastRoute {
+
+  override val route = pathPrefix("contract") {
+    create ~ contentFromName
+  }
+
+  @Path("/create")
+  @ApiOperation(value = "Creates a contract",
+    httpMethod = "POST",
+    produces = "application/json",
+    consumes = "application/json")
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(
+      name = "body",
+      value = "Json with data",
+      required = true,
+      paramType = "body",
+      dataType = "scorex.api.http.contract.CreateContractRequest",
+      defaultValue = "{\n\t\"contract\": \"contractcontract\",\n\t\"name\": \"contractname\",\n\t\"sender\": \"3Mx2afTZ2KbRrLNbytyzTtXukZvqEB8SkW7\",\n\t\"fee\": 100000\n}"
+    )
+  ))
+  @ApiResponses(Array(new ApiResponse(code = 200, message = "Json with response or error")))
+  def create: Route = processRequest("create", (t: CreateContractRequest) => doBroadcast(TransactionFactory.contract(t, wallet, time)))
+
+
+  @Path("/by-name/{name}")
+  @ApiOperation(value = "Content", notes = "Returns content associated with a contract name.", httpMethod = "GET")
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(name = "name", value = "Name", required = true, dataType = "string", paramType = "path")
+  ))
+  def contentFromName: Route = (get & path("by-name" / Segment)) { contractName =>
+    val content = state.contractContent(contractName)
+    val result = Either.cond(content.isDefined, Json.obj("content" -> content.get), ContractNotExists(contractName))
+    complete(result)
+  }
+}

--- a/src/main/scala/scorex/api/http/contract/ContractBroadcastApiRoute.scala
+++ b/src/main/scala/scorex/api/http/contract/ContractBroadcastApiRoute.scala
@@ -1,0 +1,44 @@
+package scorex.api.http.contract
+
+import javax.ws.rs.Path
+import akka.http.scaladsl.server.Route
+import com.wavesplatform.UtxPool
+import com.wavesplatform.settings.RestAPISettings
+import io.netty.channel.group.ChannelGroup
+import io.swagger.annotations._
+import scorex.BroadcastRoute
+import scorex.api.http._
+
+@Path("/contract/broadcast")
+@Api(value = "/contract")
+case class ContractBroadcastApiRoute(
+                                   settings: RestAPISettings,
+                                   utx: UtxPool,
+                                   allChannels: ChannelGroup)
+  extends ApiRoute with BroadcastRoute {
+  override val route = pathPrefix("contract" / "broadcast") {
+    signedCreate
+  }
+
+  @Path("/create")
+  @ApiOperation(value = "Broadcasts a signed create conract transaction",
+    httpMethod = "POST",
+    produces = "application/json",
+    consumes = "application/json")
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(
+      name = "body",
+      value = "Json with data",
+      required = true,
+      paramType = "body",
+      dataType = "scorex.api.http.contract.SignedCreateContractRequest",
+      defaultValue = "{\n\t\"content\": \"contractcontent\",\n\t\"name\": \"contractname\",\n\t\"senderPublicKey\": \"11111\",\n\t\"fee\": 100000\n\t\"timestamp\": 12345678,\n\t\"signature\": \"asdasdasd\"\n}"
+    )
+  ))
+  @ApiResponses(Array(new ApiResponse(code = 200, message = "Json with response or error")))
+  def signedCreate: Route = (path("create") & post) {
+    json[SignedCreateContractRequest] { contractReq =>
+      doBroadcast(contractReq.toTx)
+    }
+  }
+}

--- a/src/main/scala/scorex/api/http/contract/CreateContractRequest.scala
+++ b/src/main/scala/scorex/api/http/contract/CreateContractRequest.scala
@@ -1,0 +1,17 @@
+package scorex.api.http.contract
+
+import io.swagger.annotations.ApiModelProperty
+import play.api.libs.json.{Format, Json}
+
+case class CreateContractRequest (@ApiModelProperty(value = "Base58 encoded sender public key", required = true)
+                             sender: String,
+                             @ApiModelProperty(value = "Name", required = true)
+                             name: String,
+                             @ApiModelProperty(value = "Content", required = true)
+                             content: String,
+                             @ApiModelProperty(required = true)
+                             fee: Long)
+
+object CreateContractRequest {
+  implicit val contractRequestFormat: Format[CreateContractRequest] = Json.format
+}

--- a/src/main/scala/scorex/api/http/contract/SignedCreateContractRequest.scala
+++ b/src/main/scala/scorex/api/http/contract/SignedCreateContractRequest.scala
@@ -1,0 +1,32 @@
+package scorex.api.http.contract
+
+import io.swagger.annotations.ApiModelProperty
+import play.api.libs.json.{Format, Json}
+import scorex.account.PublicKeyAccount
+import scorex.api.http.BroadcastRequest
+import scorex.contract.Contract
+import scorex.transaction.TransactionParser.SignatureStringLength
+import scorex.transaction.{CreateContractTransaction, ValidationError}
+
+case class SignedCreateContractRequest (@ApiModelProperty(value = "Base58 encoded sender public key", required = true)
+                                        senderPublicKey: String,
+                                        @ApiModelProperty(required = true)
+                                        fee: Long,
+                                        @ApiModelProperty(value = "Name", required = true)
+                                        name: String,
+                                        @ApiModelProperty(value = "Content", required = true)
+                                        content: String,
+                                        @ApiModelProperty(required = true)
+                                        timestamp: Long,
+                                        @ApiModelProperty(required = true)
+                                        signature: String) extends BroadcastRequest {
+  def toTx: Either[ValidationError, CreateContractTransaction] = for {
+    _sender <- PublicKeyAccount.fromBase58String(senderPublicKey)
+    _signature <- parseBase58(signature, "invalid.signature", SignatureStringLength)
+    _contract <- Contract.buildContract(content, name)
+    _t <- CreateContractTransaction.create(_sender, _contract, fee, timestamp, _signature)
+  } yield _t
+}
+object SignedCreateContractRequest {
+  implicit val broadcastContractRequestReadsFormat: Format[SignedCreateContractRequest] = Json.format
+}

--- a/src/main/scala/scorex/contract/Contract.scala
+++ b/src/main/scala/scorex/contract/Contract.scala
@@ -1,0 +1,29 @@
+package scorex.contract
+
+import com.wavesplatform.state2.ByteStr
+import scorex.serialization.{BytesSerializable, Deser}
+import scorex.transaction.ValidationError
+
+sealed trait Contract {
+
+  lazy val stringRepr: String = Contract.Prefix + ":" + name
+  lazy val bytes: ByteStr = ByteStr(BytesSerializable.arrayWithSize(name.getBytes("UTF-8")) ++ content.getBytes("UTF-8"))
+
+  val name: String
+  val content: String
+}
+
+object Contract {
+
+  val Prefix: String = "contract:"
+
+  def buildContract(content: String, name: String): Either[ValidationError, Contract] = {
+    case class ContractImpl(content: String, name: String) extends Contract
+    Right(ContractImpl(content, name))
+  }
+
+  def fromBytes(bytes: Array[Byte]): Either[ValidationError, Contract] = {
+    val (nameBytes, nameEnd) = Deser.parseArraySize(bytes, 0)
+    buildContract(new String(bytes.slice(nameEnd, bytes.length), "UTF-8"), new String(nameBytes, "UTF-8"))
+  }
+}

--- a/src/main/scala/scorex/transaction/CreateContractTransaction.scala
+++ b/src/main/scala/scorex/transaction/CreateContractTransaction.scala
@@ -1,0 +1,78 @@
+package scorex.transaction
+
+import com.google.common.primitives.{Bytes, Longs}
+import com.wavesplatform.state2.ByteStr
+import play.api.libs.json.{JsObject, Json}
+import scorex.account._
+import scorex.contract.Contract
+import scorex.crypto.EllipticCurveImpl
+import scorex.crypto.hash.FastCryptographicHash
+import scorex.serialization.{BytesSerializable, Deser}
+import scorex.transaction.TransactionParser._
+
+import scala.util.{Failure, Success, Try}
+
+case class CreateContractTransaction private(sender: PublicKeyAccount,
+                                          contract: Contract,
+                                          fee: Long,
+                                          timestamp: Long,
+                                          signature: ByteStr)
+  extends SignedTransaction {
+
+  override val transactionType: TransactionType.Value = TransactionType.CreateContractTransaction
+
+  override lazy val id: ByteStr = ByteStr(FastCryptographicHash(transactionType.id.toByte +: contract.bytes.arr))
+
+  lazy val toSign: Array[Byte] = Bytes.concat(
+    Array(transactionType.id.toByte),
+    sender.publicKey,
+    BytesSerializable.arrayWithSize(contract.bytes.arr),
+    Longs.toByteArray(fee),
+    Longs.toByteArray(timestamp))
+
+  override lazy val json: JsObject = jsonBase() ++ Json.obj(
+    "contract" -> (Json.obj("name" -> contract.name, "content"->contract.content)),
+    "fee" -> fee,
+    "timestamp" -> timestamp
+  )
+
+  override val assetFee: (Option[AssetId], Long) = (None, fee)
+  override lazy val bytes: Array[Byte] = Bytes.concat(toSign, signature.arr)
+
+}
+
+object CreateContractTransaction {
+
+  def parseTail(bytes: Array[Byte]): Try[CreateContractTransaction] = Try {
+    import EllipticCurveImpl._
+    val sender = PublicKeyAccount(bytes.slice(0, KeyLength))
+    val (contractBytes, contractEnd) = Deser.parseArraySize(bytes, KeyLength)
+    (for {
+      contract <- Contract.fromBytes(contractBytes)
+      fee = Longs.fromByteArray(bytes.slice(contractEnd, contractEnd + 8))
+      timestamp = Longs.fromByteArray(bytes.slice(contractEnd + 8, contractEnd + 16))
+      signature = ByteStr(bytes.slice(contractEnd + 16, contractEnd + 16 + SignatureLength))
+      tx <- CreateContractTransaction.create(sender, contract, fee, timestamp, signature)
+    } yield tx).fold(left => Failure(new Exception(left.toString)), right => Success(right))
+  }.flatten
+
+  def create(sender: PublicKeyAccount,
+             contract: Contract,
+             fee: Long,
+             timestamp: Long,
+             signature: ByteStr): Either[ValidationError, CreateContractTransaction] =
+    if (fee <= 0) {
+      Left(ValidationError.InsufficientFee)
+    } else {
+      Right(CreateContractTransaction(sender, contract, fee, timestamp, signature))
+    }
+
+  def create(sender: PrivateKeyAccount,
+             contract: Contract,
+             fee: Long,
+             timestamp: Long): Either[ValidationError, CreateContractTransaction] = {
+    create(sender, contract, fee, timestamp, ByteStr.empty).right.map { unsigned =>
+      unsigned.copy(signature = ByteStr(EllipticCurveImpl.sign(sender, unsigned.toSign)))
+    }
+  }
+}

--- a/src/main/scala/scorex/transaction/TransactionFactory.scala
+++ b/src/main/scala/scorex/transaction/TransactionFactory.scala
@@ -5,8 +5,10 @@ import com.wavesplatform.state2.ByteStr
 import scorex.account._
 import scorex.api.http.alias.CreateAliasRequest
 import scorex.api.http.assets._
+import scorex.api.http.contract.CreateContractRequest
 import scorex.api.http.leasing.{LeaseCancelRequest, LeaseRequest}
 import scorex.api.http.spos.ContendSlotsRequest
+import scorex.contract.Contract
 import scorex.crypto.encode.Base58
 import scorex.transaction.assets._
 import scorex.transaction.lease.{LeaseCancelTransaction, LeaseTransaction}
@@ -59,7 +61,6 @@ object TransactionFactory {
       tx <- LeaseCancelTransaction.create(pk, ByteStr.decodeBase58(request.txId).get, request.fee, time.getTimestamp())
     } yield tx
 
-
   def alias(request: CreateAliasRequest, wallet: Wallet, time: Time): Either[ValidationError, CreateAliasTransaction] = for {
     senderPrivateKey <- wallet.findWallet(request.sender)
     alias <- Alias.buildWithCurrentNetworkByte(request.alias)
@@ -69,6 +70,12 @@ object TransactionFactory {
   def contendSlots(request: ContendSlotsRequest, wallet:Wallet, time: Time): Either[ValidationError, ContendSlotsTransaction] = for {
     senderPrivateKey <- wallet.findWallet(request.sender)
     tx <- ContendSlotsTransaction.create(senderPrivateKey, request.slotids, request.fee, time.getTimestamp())
+  } yield tx
+
+  def contract(request: CreateContractRequest, wallet: Wallet, time: Time): Either[ValidationError, CreateContractTransaction] = for {
+    senderPrivateKey <- wallet.findWallet(request.sender)
+    contract <- Contract.buildContract(request.content, request.name)
+    tx <- CreateContractTransaction.create(senderPrivateKey, contract, request.fee, time.getTimestamp())
   } yield tx
 
   def reissueAsset(request: ReissueRequest, wallet: Wallet, time: Time): Either[ValidationError, ReissueTransaction] = for {

--- a/src/main/scala/scorex/transaction/TransactionParser.scala
+++ b/src/main/scala/scorex/transaction/TransactionParser.scala
@@ -22,6 +22,7 @@ object TransactionParser {
     val CreateAliasTransaction = Value(10)
     val MintingTransaction = Value(11)
     val ContendSlotsTransaction = Value(12)
+    val CreateContractTransaction = Value(14)
   }
 
   val TimestampLength = 8
@@ -70,6 +71,9 @@ object TransactionParser {
       
       case txType: Byte if txType == TransactionType.ContendSlotsTransaction.id =>
         ContendSlotsTransaction.parseTail(data.tail)
+
+      case txType: Byte if txType == TransactionType.CreateContractTransaction.id =>
+        CreateContractTransaction.parseTail(data.tail)
 
       case txType => Failure(new Exception(s"Invalid transaction type: $txType"))
     }

--- a/src/test/scala/com/wavesplatform/settings/FeesSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/FeesSettingsSpecification.scala
@@ -143,10 +143,13 @@ class FeesSettingsSpecification extends FlatSpec with Matchers {
         |  minting {
         |    WAVES = 100000
         |  }
+        |  create-contract{
+        |    WAVES = 200000
+        |  }
         |}
       """.stripMargin).withFallback(defaultConfig).resolve()
     val settings = FeesSettings.fromConfig(config)
-    settings.fees.size should be(11)
+    settings.fees.size should be(12)
     settings.fees(2).toSet should equal(Set(FeeSettings("WAVES", 100000)))
     settings.fees(3).toSet should equal(Set(FeeSettings("WAVES", 100000000)))
     settings.fees(4).toSet should equal(Set(FeeSettings("WAVES", 100000), FeeSettings("6MPKrD5B7GrfbciHECg1MwdvRUhRETApgNZspreBJ8JL", 1)))
@@ -158,5 +161,6 @@ class FeesSettingsSpecification extends FlatSpec with Matchers {
     settings.fees(10).toSet should equal(Set(FeeSettings("WAVES", 100000)))
     settings.fees(11).toSet should equal(Set(FeeSettings("WAVES", 100000)))
     settings.fees(12).toSet should equal(Set(FeeSettings("WAVES", 10000000)))
+    settings.fees(14).toSet should equal(Set(FeeSettings("WAVES", 200000)))
   }
 }

--- a/template.conf
+++ b/template.conf
@@ -2,9 +2,9 @@ waves {
   #directory = tmp/waves
   logging-level = DEBUG
   network {
-    known-peers = ["172.17.0.2"]
+    known-peers = ["localhost:16863","172.17.0.2:6863"]
     black-list-residence-time = 30s
-    peers-broadcast-interval = 2s
+    peers-broadcast-interval = 5s
     connection-timeout = 30s
   }
   wallet {
@@ -36,7 +36,7 @@ waves {
       genesis {
         timestamp = 1528036610296763852
         block-timestamp = 1528036610296763852
-        signature = 5JY5NvSfyT3fu2nurcHB5sZojeXY43dT9vxcBbcTMd61T3wYV9e7n74f3Dh8iRL39YB2TfQpvHBqkLJk97TTW69S
+        signature = 1Lmo9uYoqb4rrG7P589qx4Nrso41WZiELRHV7AnoY8jP8qTWRb9zuCYJumqNGTEckRL2E7TJHP2QyWykx7pBnHQ
         initial-balance =  1000000000000000
         initial-base-target = 153722867
         average-block-delay = 60s
@@ -68,7 +68,8 @@ waves {
   rest-api {
     enable = yes
     bind-address = 0.0.0.0
-    api-key-hash = 5yPkqXs6RbAte8GysnqpTudkPhxycZJvteQYuo8vt5Xs
+    #api key wavestest2018 for hash 9t8DxH6z99toHVe5htCH9SvWKbaCh45JbMnF43mDGHnZ
+    api-key-hash = 9t8DxH6z99toHVe5htCH9SvWKbaCh45JbMnF43mDGHnZ
   }
   utx.broadcast-interval = 3s
 }


### PR DESCRIPTION
first version of create contract transaction code, very basic just have name/content pair. 
use kate's version of apikey wavestest2018 to test the create/get api
fee is 200000 WAVES, 
changed peers-broadcast-interval = 5s to print less logs
already rebased from current master so should have no conflict
