### PR TITLE
to prepare for the first launch for testnet, comment out those transa…

### DIFF
--- a/src/main/scala/com/wavesplatform/state2/diffs/TransactionDiffer.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/TransactionDiffer.scala
@@ -7,8 +7,8 @@ import com.wavesplatform.state2.reader.StateReader
 import scorex.transaction.ValidationError.UnsupportedTransactionType
 import scorex.transaction._
 import scorex.transaction.assets._
-import scorex.transaction.assets.exchange.ExchangeTransaction
-import scorex.transaction.contract.{ChangeContractStatusTransaction, CreateContractTransaction}
+//import scorex.transaction.assets.exchange.ExchangeTransaction
+//import scorex.transaction.contract.{ChangeContractStatusTransaction, CreateContractTransaction}
 import scorex.transaction.database.DbPutTransaction
 import scorex.transaction.lease.{LeaseCancelTransaction, LeaseTransaction}
 import vee.transaction.MintingTransaction
@@ -28,19 +28,19 @@ object TransactionDiffer {
       diff <- t5 match {
         case gtx: GenesisTransaction => GenesisTransactionDiff(currentBlockHeight)(gtx)
         case ptx: PaymentTransaction => PaymentTransactionDiff(s, currentBlockHeight, settings, currentBlockTimestamp)(ptx)
-        case itx: IssueTransaction => AssetTransactionsDiff.issue(currentBlockHeight)(itx)
-        case rtx: ReissueTransaction => AssetTransactionsDiff.reissue(s, settings, currentBlockTimestamp, currentBlockHeight)(rtx)
-        case btx: BurnTransaction => AssetTransactionsDiff.burn(s, currentBlockHeight)(btx)
-        case ttx: TransferTransaction => TransferTransactionDiff(s, settings, currentBlockTimestamp, currentBlockHeight)(ttx)
+        //case itx: IssueTransaction => AssetTransactionsDiff.issue(currentBlockHeight)(itx)
+        //case rtx: ReissueTransaction => AssetTransactionsDiff.reissue(s, settings, currentBlockTimestamp, currentBlockHeight)(rtx)
+        //case btx: BurnTransaction => AssetTransactionsDiff.burn(s, currentBlockHeight)(btx)
+        //case ttx: TransferTransaction => TransferTransactionDiff(s, settings, currentBlockTimestamp, currentBlockHeight)(ttx)
         case ltx: LeaseTransaction => LeaseTransactionsDiff.lease(s, currentBlockHeight)(ltx)
         case ltx: LeaseCancelTransaction => LeaseTransactionsDiff.leaseCancel(s, settings, currentBlockTimestamp, currentBlockHeight)(ltx)
-        case etx: ExchangeTransaction => ExchangeTransactionDiff(s, currentBlockHeight)(etx)
-        case atx: CreateAliasTransaction => CreateAliasTransactionDiff(currentBlockHeight)(atx)
+        //case etx: ExchangeTransaction => ExchangeTransactionDiff(s, currentBlockHeight)(etx)
+        //case atx: CreateAliasTransaction => CreateAliasTransactionDiff(currentBlockHeight)(atx)
         case mtx: MintingTransaction => MintingTransactionDiff(s, currentBlockHeight, settings, currentBlockTimestamp)(mtx)
         case cstx: ContendSlotsTransaction => ContendSlotsTransactionDiff(s,settings,currentBlockHeight)(cstx)
         case rstx: ReleaseSlotsTransaction => ReleaseSlotsTransactionDiff(s,settings,currentBlockHeight)(rstx)
-        case cctx: CreateContractTransaction => ContractTransactionDiff.create(s, currentBlockHeight)(cctx)
-        case ccstx: ChangeContractStatusTransaction => ContractTransactionDiff.changeStatus(s, currentBlockHeight)(ccstx)
+        //case cctx: CreateContractTransaction => ContractTransactionDiff.create(s, currentBlockHeight)(cctx)
+        //case ccstx: ChangeContractStatusTransaction => ContractTransactionDiff.changeStatus(s, currentBlockHeight)(ccstx)
         case dptx: DbPutTransaction => DbTransactionDiff.put(s, currentBlockHeight)(dptx)
         case _ => Left(UnsupportedTransactionType)
       }

--- a/src/test/scala/com/wavesplatform/state2/diffs/AssetTransactionsDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/AssetTransactionsDiffTest.scala
@@ -5,11 +5,12 @@ import com.wavesplatform.TransactionGen
 import com.wavesplatform.state2._
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.{Ignore, Matchers, PropSpec}
 import scorex.lagonaki.mocks.TestBlock
 import scorex.transaction.GenesisTransaction
 import scorex.transaction.assets.{BurnTransaction, IssueTransaction, ReissueTransaction}
 
+@Ignore
 class AssetTransactionsDiffTest extends PropSpec with PropertyChecks with GeneratorDrivenPropertyChecks with Matchers with TransactionGen {
 
   private implicit def noShrink[A]: Shrink[A] = Shrink(_ => Stream.empty)

--- a/src/test/scala/com/wavesplatform/state2/diffs/CreateAliasTransactionDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/CreateAliasTransactionDiffTest.scala
@@ -5,12 +5,13 @@ import com.wavesplatform.TransactionGen
 import com.wavesplatform.state2._
 import org.scalacheck.{Gen, Shrink}
 import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.{Ignore, Matchers, PropSpec}
 import scorex.account.PrivateKeyAccount
 import scorex.lagonaki.mocks.TestBlock
 import scorex.transaction.assets.IssueTransaction
 import scorex.transaction.{CreateAliasTransaction, GenesisTransaction}
 
+@Ignore
 class CreateAliasTransactionDiffTest extends PropSpec with PropertyChecks with GeneratorDrivenPropertyChecks with Matchers with TransactionGen {
 
   private implicit def noShrink[A]: Shrink[A] = Shrink(_ => Stream.empty)

--- a/src/test/scala/com/wavesplatform/state2/diffs/ExchangeTransactionDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/ExchangeTransactionDiffTest.scala
@@ -7,7 +7,7 @@ import com.wavesplatform.state2._
 import com.wavesplatform.state2.diffs.TransactionDiffer.TransactionValidationError
 import org.scalacheck.{Gen, Shrink}
 import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
-import org.scalatest.{Inside, Matchers, PropSpec}
+import org.scalatest.{Ignore, Inside, Matchers, PropSpec}
 import scorex.account.PrivateKeyAccount
 import scorex.lagonaki.mocks.TestBlock
 import scorex.transaction.ValidationError.AccountBalanceError
@@ -15,6 +15,7 @@ import scorex.transaction.assets.IssueTransaction
 import scorex.transaction.assets.exchange.{AssetPair, ExchangeTransaction, Order}
 import scorex.transaction.{GenesisTransaction, ValidationError}
 
+@Ignore
 class ExchangeTransactionDiffTest extends PropSpec with PropertyChecks with GeneratorDrivenPropertyChecks
   with Matchers with TransactionGen with Inside {
 

--- a/src/test/scala/com/wavesplatform/state2/diffs/TransferTransactionDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/TransferTransactionDiffTest.scala
@@ -5,12 +5,13 @@ import com.wavesplatform.TransactionGen
 import com.wavesplatform.state2._
 import org.scalacheck.{Gen, Shrink}
 import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.{Ignore, Matchers, PropSpec}
 import scorex.account.Address
 import scorex.lagonaki.mocks.TestBlock
 import scorex.transaction.GenesisTransaction
 import scorex.transaction.assets.{IssueTransaction, TransferTransaction}
 
+@Ignore
 class TransferTransactionDiffTest extends PropSpec with PropertyChecks with GeneratorDrivenPropertyChecks with Matchers with TransactionGen {
 
   private implicit def noShrink[A]: Shrink[A] = Shrink(_ => Stream.empty)


### PR DESCRIPTION
to prepare for the first launch for testnet, comment out those transaction types we won't support in the first release but keep the api til testnet launched(so we can test validation)

the transaction types we donot support in first release are IssueTransaction, ReissueTransaction, BurnTransaction, TransferTransaction, ExchangeTransaction, CreateAliasTransaction, CreateContractTransaction and ChangeContractStatusTransaction
also fix corresponding test cases

did not delete those codes, just commented out in case we need them later