### PR TITLE
Switch p2p, api and matcher ports

### DIFF
--- a/generator/src/main/resources/application.conf
+++ b/generator/src/main/resources/application.conf
@@ -10,7 +10,7 @@ generator {
   every = 1 minute
   send-to {
     address = 52.30.47.67
-    port = 6863
+    port = 9923
   }
   probabilities {
     payment: 0.1

--- a/src/it/container/start-vee.sh
+++ b/src/it/container/start-vee.sh
@@ -8,4 +8,4 @@ echo Waves: $WAVES_NET_IP
 echo Options: $WAVES_OPTS
 
 #java -Dwaves.network.declared-address=$WAVES_NET_IP:$WAVES_PORT $WAVES_OPTS -jar /opt/vee/vee.jar /opt/vee/template.conf
-java -Dwaves.network.declared-address=$DEFAULT_NET_IP:6863 $WAVES_OPTS -jar /opt/vee/vee.jar /opt/vee/template.conf
+java -Dwaves.network.declared-address=$DEFAULT_NET_IP:9923 $WAVES_OPTS -jar /opt/vee/vee.jar /opt/vee/template.conf

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -27,13 +27,13 @@ waves {
     # In some cases, you may both set `decalred-address` and enable UPnP (e.g. when IGD can't reliably determine its
     # external IP address). In such cases the node will attempt to configure an IGD to pass traffic from external port
     # to `bind-address:port`. Please note, however, that this setup is not recommended.
-    # declared-address = "1.2.3.4:6863"
+    # declared-address = "1.2.3.4:9923"
 
     # Network address
     bind-address = "0.0.0.0"
 
     # Port number
-    port = 6863
+    port = 9923
 
     # Node name to send during handshake. Comment this string out to set random node name.
     # node-name = "default-node-name"
@@ -42,7 +42,7 @@ waves {
     # nonce = 0
 
     # List of IP addresses of well known nodes.
-    known-peers = ["52.30.47.67:6863", "52.28.66.217:6863", "52.77.111.219:6863", "52.51.92.182:6863"]
+    known-peers = []
 
     # How long the information about peer stays in database after the last communication with it
     peers-data-residence-time = 1d
@@ -228,7 +228,7 @@ waves {
     bind-address = "127.0.0.1"
 
     # Matcher REST API port
-    port = 6886
+    port = 9925
 
     # Minimum allowed order fee
     min-order-fee = 300000
@@ -286,7 +286,7 @@ waves {
     bind-address = "127.0.0.1"
 
     # Port to listen to REST API requests
-    port = 6869
+    port = 9922
 
     # Hash of API key string
     api-key-hash = "H6nsiifwYKYEx6YzYD7woP1XCn72RVvx6tC1zjjLXqsu"

--- a/src/main/scala/com/wavesplatform/network/PeerDatabaseImpl.scala
+++ b/src/main/scala/com/wavesplatform/network/PeerDatabaseImpl.scala
@@ -18,7 +18,7 @@ class PeerDatabaseImpl(settings: NetworkSettings) extends PeerDatabase with Auto
   private val blacklist = database.openMap("blacklist", new LogMVMapBuilder[InetAddress, Long])
   private val unverifiedPeers = EvictingQueue.create[InetSocketAddress](settings.maxUnverifiedPeers)
 
-  for (a <- settings.knownPeers.view.map(inetSocketAddress(_, 6863))) {
+  for (a <- settings.knownPeers.view.map(inetSocketAddress(_, 9923))) {
     // add peers from config with max timestamp so they never get evicted from the list of known peers
     doTouch(a, Long.MaxValue)
   }

--- a/src/test/scala/com/wavesplatform/matcher/MatcherTestData.scala
+++ b/src/test/scala/com/wavesplatform/matcher/MatcherTestData.scala
@@ -37,7 +37,7 @@ trait MatcherTestData {
       |    enable: yes
       |    account: ""
       |    bind-address: "127.0.0.1"
-      |    port: 6886
+      |    port: 9925
       |    order-history-file: null
       |    min-order-fee: 100000
       |    order-match-tx-fee: 100000

--- a/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/MatcherSettingsSpecification.scala
@@ -15,7 +15,7 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
         |    enable: yes
         |    account: "BASE58MATCHERACCOUNT"
         |    bind-address: "127.0.0.1"
-        |    port: 6886
+        |    port: 9925
         |    min-order-fee: 100000
         |    order-match-tx-fee: 100000
         |    snapshots-interval: 1d
@@ -40,7 +40,7 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
     settings.enable should be(true)
     settings.account should be("BASE58MATCHERACCOUNT")
     settings.bindAddress should be("127.0.0.1")
-    settings.port should be(6886)
+    settings.port should be(9925)
     settings.minOrderFee should be(100000)
     settings.orderMatchTxFee should be(100000)
     settings.journalDataDir should be("/waves/matcher/journal")

--- a/src/test/scala/com/wavesplatform/settings/NetworkSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/NetworkSettingsSpecification.scala
@@ -16,11 +16,11 @@ class NetworkSettingsSpecification extends FlatSpec with Matchers {
       """waves.network {
         |  file: /waves/peers.dat
         |  bind-address: "127.0.0.1"
-        |  port: 6868
+        |  port: 9921
         |  node-name: "default-node-name"
-        |  declared-address: "127.0.0.1:6868"
+        |  declared-address: "127.0.0.1:9921"
         |  nonce: 0
-        |  known-peers = ["8.8.8.8:6868", "4.4.8.8:6868"]
+        |  known-peers = ["8.8.8.8:9921", "4.4.8.8:9921"]
         |  local-only: no
         |  peers-data-residence-time: 1d
         |  black-list-residence-time: 10m
@@ -43,11 +43,11 @@ class NetworkSettingsSpecification extends FlatSpec with Matchers {
     val networkSettings = config.as[NetworkSettings]("waves.network")
 
     networkSettings.file should be(Some(new File("/waves/peers.dat")))
-    networkSettings.bindAddress should be(new InetSocketAddress("127.0.0.1", 6868))
+    networkSettings.bindAddress should be(new InetSocketAddress("127.0.0.1", 9921))
     networkSettings.nodeName should be("default-node-name")
-    networkSettings.declaredAddress should be(Some(new InetSocketAddress("127.0.0.1", 6868)))
+    networkSettings.declaredAddress should be(Some(new InetSocketAddress("127.0.0.1", 9921)))
     networkSettings.nonce should be(0)
-    networkSettings.knownPeers should be(List("8.8.8.8:6868", "4.4.8.8:6868"))
+    networkSettings.knownPeers should be(List("8.8.8.8:9921", "4.4.8.8:9921"))
     networkSettings.peersDataResidenceTime should be(1.day)
     networkSettings.blackListResidenceTime should be(10.minutes)
     networkSettings.maxInboundConnections should be(30)

--- a/src/test/scala/com/wavesplatform/settings/RestAPISettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/RestAPISettingsSpecification.scala
@@ -11,7 +11,7 @@ class RestAPISettingsSpecification extends FlatSpec with Matchers {
         |  rest-api {
         |    enable: yes
         |    bind-address: "127.0.0.1"
-        |    port: 6869
+        |    port: 9922
         |    api-key-hash: "BASE58APIKEYHASH"
         |    cors: yes
         |  }
@@ -21,7 +21,7 @@ class RestAPISettingsSpecification extends FlatSpec with Matchers {
 
     settings.enable should be(true)
     settings.bindAddress should be("127.0.0.1")
-    settings.port should be(6869)
+    settings.port should be(9922)
     settings.apiKeyHash should be ("BASE58APIKEYHASH")
     settings.cors should be(true)
   }

--- a/vee-devnet.conf
+++ b/vee-devnet.conf
@@ -112,7 +112,7 @@ waves {
     bind-address = "0.0.0.0"
 
     # Port to listen to REST API requests
-    port = 6869
+    port = 9922
 
     # Hash of API key string
     api-key-hash = "7B74gZMpdzQSB45A7KRwKW6mDUYaWhFY8kWh5qiLRRoA"

--- a/vee-mainnet.conf
+++ b/vee-mainnet.conf
@@ -5,19 +5,19 @@ waves {
 
   # P2P Network settings
   network {
-    known-peers = ["138.201.152.163:6868", "138.201.152.164:6868", "138.201.152.165:6868", "35.156.19.4:6868", "52.50.69.247:6868", "52.57.147.71:6868"]
+    known-peers = []
 
     # Network address
     bind-address = "0.0.0.0"
 
     # Port number
-    port = 6868
+    port = 9921
 
     # Node name to send during handshake. Comment this string out to set random node name.
     # node-name = "My MAINNET node"
 
     # String with IP address and port to send as external address during handshake. Could be set automatically if uPnP is enabled.
-    # declared-address = "1.2.3.4:6868"
+    # declared-address = "1.2.3.4:9921"
   }
 
   # Wallet settings
@@ -44,7 +44,7 @@ waves {
     bind-address = "127.0.0.1"
 
     # Matcher REST API port
-    port = 6886
+    port = 9925
   }
 
   # Node's REST API settings
@@ -56,7 +56,7 @@ waves {
     bind-address = "127.0.0.1"
 
     # Port to listen to REST API requests
-    port = 6869
+    port = 9922
 
     # Hash of API key string
     api-key-hash = "H6nsiifwYKYEx6YzYD7woP1XCn72RVvx6tC1zjjLXqsu"

--- a/vee-testnet.conf
+++ b/vee-testnet.conf
@@ -2,8 +2,7 @@ waves {
   # directory = /home/host/git/VEE/tmp/waves
   logging-level = DEBUG
   network {
-  #  known-peers = ["54.152.46.6:6863"]
-    known-peers = ["54.146.57.65:6863"]
+    known-peers = []
     black-list-residence-time = 30s
     peers-broadcast-interval = 2s
     connection-timeout = 30s


### PR DESCRIPTION
Assigning new listening ports for VEE:

mainnet p2p port 6868 -> 9921
testnet p2p port 6863 -> 9923
api port 6869 -> 9922
match port 6886 -> 9925

Passed unit tests and manual node startup.

Note: Currently mainnet node and testnet node still share the api port. In the future it's best to use separate api port. Port 9924 should be reserved for testnet api port.