### PR TITLE
spos api request test

### DIFF
--- a/src/test/scala/vee/transaction/api/http/spos/SPOSRequestsTests.scala
+++ b/src/test/scala/vee/transaction/api/http/spos/SPOSRequestsTests.scala
@@ -1,0 +1,79 @@
+package vee.transaction.api.http.spos
+
+import org.scalatest.{FunSuite, Matchers}
+import play.api.libs.json.Json
+import vee.api.http.spos
+import vee.api.http.spos.{ContendSlotsRequest, ReleaseSlotsRequest, SignedContendSlotsRequest, SignedReleaseSlotsRequest}
+
+class SPOSRequestsTests extends FunSuite with Matchers {
+
+  test("ContendSlotsRequest") {
+    val json =
+      """
+        {
+          "sender": "3MwKzMxUKaDaS4CXM8KNowCJJUnTSHDFGMb",
+          "fee": 100000000000,
+          "feeScale": 100,
+          "slotId": 0
+        }
+      """
+
+    val req = Json.parse(json).validate[ContendSlotsRequest].get
+
+    req shouldBe ContendSlotsRequest("3MwKzMxUKaDaS4CXM8KNowCJJUnTSHDFGMb", 0, 100000000000L, 100)
+  }
+
+  test("ReleaseSlotsRequest") {
+    val json =
+      """
+        {
+          "sender": "3Myss6gmMckKYtka3cKCM563TBJofnxvfD7",
+          "fee": 100000000000,
+          "feeScale": 100,
+          "slotId": 0
+        }
+      """
+
+    val req = Json.parse(json).validate[ReleaseSlotsRequest].get
+
+    req shouldBe ReleaseSlotsRequest("3Myss6gmMckKYtka3cKCM563TBJofnxvfD7", 0, 100000000000L, 100)
+  }
+
+  test("SignedContendSlotsRequest") {
+    val json =
+      """
+        {
+         "senderPublicKey":"CRxqEuxhdZBEHX42MU4FfyJxuHmbDBTaHMhM3Uki7pLw",
+         "slotId": 0,
+         "fee":100000000000,
+         "feeScale": 100,
+         "timestamp":0,
+         "signature":"4VPg4piLZGQz3vBqCPbjTfAR4cDErMi57rDvyith5XrQJDLryU2w2JsL3p4ejEqTPpctZ5YekpQwZPTtYiGo5yPC"
+         }
+      """
+
+    val req = Json.parse(json).validate[SignedContendSlotsRequest].get
+
+    req shouldBe spos.SignedContendSlotsRequest("CRxqEuxhdZBEHX42MU4FfyJxuHmbDBTaHMhM3Uki7pLw",100000000000L, 100, 0,
+      0L, "4VPg4piLZGQz3vBqCPbjTfAR4cDErMi57rDvyith5XrQJDLryU2w2JsL3p4ejEqTPpctZ5YekpQwZPTtYiGo5yPC")
+  }
+
+  test("SignedReleaseSlotsRequest") {
+    val json =
+      """
+        {
+         "senderPublicKey":"CRxqEuxhdZBEHX42MU4FfyJxuHmbDBTaHMhM3Uki7pLw",
+         "slotId": 0,
+         "timestamp":0,
+         "fee": 100000000000,
+         "feeScale": 100,
+         "signature":"4VPg4piLZGQz3vBqCPbjTfAR4cDErMi57rDvyith5XrQJDLryU2w2JsL3p4ejEqTPpctZ5YekpQwZPTtYiGo5yPC"
+         }
+      """
+
+    val req = Json.parse(json).validate[SignedReleaseSlotsRequest].get
+
+    req shouldBe spos.SignedReleaseSlotsRequest("CRxqEuxhdZBEHX42MU4FfyJxuHmbDBTaHMhM3Uki7pLw",
+      100000000000L, 100, 0, 0L, "4VPg4piLZGQz3vBqCPbjTfAR4cDErMi57rDvyith5XrQJDLryU2w2JsL3p4ejEqTPpctZ5YekpQwZPTtYiGo5yPC")
+  }
+}


### PR DESCRIPTION
add spos api request

unit test passed
```scala
[info] SPOSRequestsTests:
[info] - ContendSlotsRequest (4 milliseconds)
[info] - ReleaseSlotsRequest (4 milliseconds)
[info] - SignedContendSlotsRequest (4 milliseconds)
[info] - SignedReleaseSlotsRequest (4 milliseconds)
[info] ScalaTest
[info] Run completed in 1 minute, 29 seconds.
[info] Total number of tests run: 283
[info] Suites: completed 88, aborted 0
[info] Tests: succeeded 283, failed 0, canceled 0, ignored 14, pending 2
[info] All tests passed.
[info] Passed: Total 283, Failed 0, Errors 0, Passed 283, Ignored 14, Pending 2
[success] Total time: 98 s, completed Aug 10, 2018 2:47:40 PM

```