### PR TITLE
change default fee asset id to VEE

### DIFF
--- a/generator/src/main/scala/com.wavesplatform.generator/TransactionGenerator.scala
+++ b/generator/src/main/scala/com.wavesplatform.generator/TransactionGenerator.scala
@@ -35,7 +35,7 @@ object TransactionGenerator {
           n: Int): Seq[Transaction] = {
     val issueTransactionSender = randomFrom(accounts).get
     val tradeAssetIssue = IssueTransaction.create(issueTransactionSender, "TRADE".getBytes,
-      "Waves DEX is the best exchange ever".getBytes, 100000000, 2, reissuable = false,
+      "VEE DEX is the best exchange ever".getBytes, 100000000, 2, reissuable = false,
       100000000L + r.nextInt(100000000), System.currentTimeMillis()).right.get
 
     val tradeAssetDistribution = {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -170,49 +170,49 @@ waves {
   # Transaction fees for different types of transactions
   fees {
     payment {
-      WAVES = 10000000
+      VEE = 10000000
     }
     issue {
-      WAVES = 100000000
+      VEE = 100000000
     }
     transfer {
-      WAVES = 10000000
+      VEE = 10000000
     }
     reissue {
-      WAVES = 10000000
+      VEE = 10000000
     }
     burn {
-      WAVES = 10000000
+      VEE = 10000000
     }
     exchange {
-      WAVES = 30000000
+      VEE = 30000000
     }
     lease {
-      WAVES = 10000000
+      VEE = 10000000
     }
     lease-cancel {
-      WAVES = 10000000
+      VEE = 10000000
     }
     create-alias {
-      WAVES = 10000000
+      VEE = 10000000
     }
     contend-slots {
-      WAVES = 100000000000
+      VEE = 100000000000
     }
     release-slots {
-      WAVES = 10000000
+      VEE = 10000000
     }
     minting {
-      WAVES = 100000
+      VEE = 100000
     }
     create-contract {
-      WAVES = 20000000
+      VEE = 20000000
     }
     change-contract-status {
-      WAVES = 10000000
+      VEE = 10000000
     }
     db-put {
-      WAVES = 100000000
+      VEE = 100000000
     }
   }
 
@@ -354,7 +354,7 @@ kamon {
 
     # Information about the node
     simple-metric-key-generator {
-      application = "waves-node"
+      application = "vee-node"
       hostname-override = ${?waves.network.node-name}
     }
   }

--- a/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
+++ b/src/main/scala/com/wavesplatform/matcher/api/MatcherApiRoute.scala
@@ -62,8 +62,8 @@ case class MatcherApiRoute(wallet: Wallet,storedState: StateReader,
   @ApiOperation(value = "Get Order Book for a given Asset Pair",
     notes = "Get Order Book for a given Asset Pair", httpMethod = "GET")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
-    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
     new ApiImplicitParam(name = "depth", value = "Limit the number of bid/ask records returned", required = false, dataType = "integer", paramType = "query")
   ))
   def orderBook: Route = (path("orderbook" / Segment / Segment) & get) { (a1, a2) =>
@@ -111,8 +111,8 @@ case class MatcherApiRoute(wallet: Wallet,storedState: StateReader,
     produces = "application/json",
     consumes = "application/json")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
-    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
     new ApiImplicitParam(
       name = "body",
       value = "Json with data",
@@ -138,8 +138,8 @@ case class MatcherApiRoute(wallet: Wallet,storedState: StateReader,
     produces = "application/json",
     consumes = "application/json")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
-    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
     new ApiImplicitParam(
       name = "body",
       value = "Json with data",
@@ -179,8 +179,8 @@ case class MatcherApiRoute(wallet: Wallet,storedState: StateReader,
     notes = "Get Order History for a given Asset Pair and Public Key",
     httpMethod = "GET")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
-    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
     new ApiImplicitParam(name = "publicKey", value = "Public Key", required = true, dataType = "string", paramType = "path"),
     new ApiImplicitParam(name = "Timestamp", value = "Timestamp", required = true, dataType = "integer", paramType = "header"),
     new ApiImplicitParam(name = "Signature", value = "Signature of [Public Key ++ Timestamp] bytes", required = true, dataType = "string", paramType = "header")
@@ -220,8 +220,8 @@ case class MatcherApiRoute(wallet: Wallet,storedState: StateReader,
     notes = "Get Tradable balance for the given Asset Pair",
     httpMethod = "GET")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
-    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
     new ApiImplicitParam(name = "address", value = "Account Address", required = true, dataType = "string", paramType = "path")
   ))
   def getTradableBalance: Route = (path("orderbook" / Segment / Segment / "tradableBalance" / Segment) & get) { (a1, a2, address) =>
@@ -237,8 +237,8 @@ case class MatcherApiRoute(wallet: Wallet,storedState: StateReader,
     notes = "Get Order status for a given Asset Pair during the last 30 days",
     httpMethod = "GET")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
-    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
     new ApiImplicitParam(name = "orderId", value = "Order Id", required = true, dataType = "string", paramType = "path")
   ))
   def orderStatus: Route = (path("orderbook" / Segment / Segment / Segment) & get) { (a1, a2, orderId) =>
@@ -264,8 +264,8 @@ case class MatcherApiRoute(wallet: Wallet,storedState: StateReader,
   @ApiOperation(value = "Remove Order Book for a given Asset Pair",
     notes = "Remove Order Book for a given Asset Pair", httpMethod = "DELETE")
   @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path"),
-    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'WAVES'", dataType = "string", paramType = "path")
+    new ApiImplicitParam(name = "amountAsset", value = "Amount Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path"),
+    new ApiImplicitParam(name = "priceAsset", value = "Price Asset Id in Pair, or 'VEE'", dataType = "string", paramType = "path")
   ))
   def orderBookDelete: Route = (path("orderbook" / Segment / Segment) & delete & withAuth) { (a1, a2) =>
     withAssetPair(a1, a2) { pair =>

--- a/src/main/scala/com/wavesplatform/matcher/market/MatcherActor.scala
+++ b/src/main/scala/com/wavesplatform/matcher/market/MatcherActor.scala
@@ -30,10 +30,10 @@ class MatcherActor(orderHistory: ActorRef, storedState: StateReader, wallet: Wal
   val tradedPairs = mutable.Map.empty[AssetPair, MarketData]
 
   def getAssetName(asset: Option[AssetId]): String =
-    asset.map(storedState.getAssetName).getOrElse(AssetPair.WavesName)
+    asset.map(storedState.getAssetName).getOrElse(AssetPair.VEEName)
 
   def createOrderBook(pair: AssetPair): ActorRef = {
-    def getAssetName(asset: Option[AssetId]): String = asset.map(storedState.getAssetName).getOrElse(AssetPair.WavesName)
+    def getAssetName(asset: Option[AssetId]): String = asset.map(storedState.getAssetName).getOrElse(AssetPair.VEEName)
 
     val md = MarketData(pair, getAssetName(pair.amountAsset), getAssetName(pair.priceAsset), NTP.correctedTime(),
       pair.amountAsset.flatMap(storedState.getIssueTransaction).map(t => AssetInfo(t.decimals)),

--- a/src/main/scala/com/wavesplatform/matcher/model/MatcherModel.scala
+++ b/src/main/scala/com/wavesplatform/matcher/model/MatcherModel.scala
@@ -33,9 +33,9 @@ sealed trait  LimitOrder {
   def rcvAcc: AssetAcc = AssetAcc(order.senderPublicKey, order.getReceiveAssetId)
   def feeAcc: AssetAcc = AssetAcc(order.senderPublicKey, None)
 
-  def spentAsset: String = order.getSpendAssetId.map(_.base58).getOrElse(AssetPair.WavesName)
-  def rcvAsset: String = order.getReceiveAssetId.map(_.base58).getOrElse(AssetPair.WavesName)
-  def feeAsset: String = AssetPair.WavesName
+  def spentAsset: String = order.getSpendAssetId.map(_.base58).getOrElse(AssetPair.VEEName)
+  def rcvAsset: String = order.getReceiveAssetId.map(_.base58).getOrElse(AssetPair.VEEName)
+  def feeAsset: String = AssetPair.VEEName
 }
 
 case class BuyLimitOrder(price: Price, amount: Long, order: Order) extends LimitOrder {

--- a/src/main/scala/com/wavesplatform/matcher/model/OrderHistory.scala
+++ b/src/main/scala/com/wavesplatform/matcher/model/OrderHistory.scala
@@ -107,7 +107,7 @@ case class OrderHistoryImpl(p: OrderHistoryStorage) extends OrderHistory with Sc
   }
 
   override def openVolume(assetAcc: AssetAcc): Long = {
-    val asset = assetAcc.assetId.map(_.base58).getOrElse(AssetPair.WavesName)
+    val asset = assetAcc.assetId.map(_.base58).getOrElse(AssetPair.VEEName)
     Option(p.addressToOrderPortfolio.get(assetAcc.account.address)).flatMap(_.get(asset)).map(math.max(0L, _)).getOrElse(0L)
   }
 

--- a/src/main/scala/com/wavesplatform/matcher/model/OrderValidator.scala
+++ b/src/main/scala/com/wavesplatform/matcher/model/OrderValidator.scala
@@ -28,7 +28,7 @@ trait OrderValidator {
 
     val b: Map[String, Long] = (Map(lo.spentAcc -> 0L) ++ Map(lo.feeAcc -> 0L))
       .map { case(a, _) => a -> spendableBalance(a) }
-      .map { case(a, v) => a.assetId.map(_.base58).getOrElse(AssetPair.WavesName) -> v }
+      .map { case(a, v) => a.assetId.map(_.base58).getOrElse(AssetPair.VEEName) -> v }
 
     val newOrder = Events.createOpenPortfolio(OrderAdded(lo)).getOrElse(order.senderPublicKey.address, OpenPortfolio.empty)
     val open = orderHistory.openPortfolio(order.senderPublicKey.address).orders.filter { case (k, _) => b.contains(k) }

--- a/src/main/scala/com/wavesplatform/state2/diffs/BalanceDiffValidation.scala
+++ b/src/main/scala/com/wavesplatform/state2/diffs/BalanceDiffValidation.scala
@@ -23,7 +23,7 @@ object BalanceDiffValidation {
       val newPortfolio = oldPortfolio.combine(portfolioDiff)
 
       val err = if (newPortfolio.balance < 0) {
-        Some(s"negative waves balance: $acc, old: ${oldPortfolio.balance}, new: ${newPortfolio.balance}")
+        Some(s"negative vee balance: $acc, old: ${oldPortfolio.balance}, new: ${newPortfolio.balance}")
       } else if (newPortfolio.assets.values.exists(_ < 0)) {
         Some(s"negative asset balance: $acc, new portfolio: ${negativeAssetsInfo(newPortfolio)}")
       } else if (newPortfolio.effectiveBalance < 0) {

--- a/src/main/scala/scorex/consensus/TransactionsOrdering.scala
+++ b/src/main/scala/scorex/consensus/TransactionsOrdering.scala
@@ -3,7 +3,7 @@ package scorex.consensus
 import scorex.transaction.Transaction
 
 object TransactionsOrdering {
-  trait WavesOrdering extends Ordering[Transaction] {
+  trait VEEOrdering extends Ordering[Transaction] {
     def txTimestampOrder(ts: Long): Long
     private def orderBy(t: Transaction): (Short, Long, Long, String) = {
       val byFeeScale: Short = (-t.assetFee._3).toShort
@@ -18,12 +18,12 @@ object TransactionsOrdering {
     }
   }
 
-  object InBlock extends WavesOrdering {
+  object InBlock extends VEEOrdering {
     // sorting from network start
     override def txTimestampOrder(ts: Long): Long = -ts
   }
 
-  object InUTXPool extends WavesOrdering {
+  object InUTXPool extends VEEOrdering {
     override def txTimestampOrder(ts: Long): Long = ts
   }
 }

--- a/src/main/scala/scorex/transaction/FeeCalculator.scala
+++ b/src/main/scala/scorex/transaction/FeeCalculator.scala
@@ -13,7 +13,7 @@ class FeeCalculator(settings: FeesSettings) {
     settings.fees.flatMap { fs =>
       val transactionType = fs._1
       fs._2.map { v =>
-        val maybeAsset = if (v.asset.toUpperCase == "WAVES") None else ByteStr.decodeBase58(v.asset).toOption
+        val maybeAsset = if (v.asset.toUpperCase == "VEE") None else ByteStr.decodeBase58(v.asset).toOption
         val fee = v.fee
 
         TransactionAssetFee(transactionType, maybeAsset).key -> fee
@@ -27,7 +27,7 @@ class FeeCalculator(settings: FeesSettings) {
         if (minimumFee <= tx.assetFee._2) {
           Right(tx)
         } else {
-          Left(GenericError(s"Fee in ${tx.assetFee._1.fold("WAVES")(_.toString)} for ${tx.transactionType} transaction does not exceed minimal value of $minimumFee"))
+          Left(GenericError(s"Fee in ${tx.assetFee._1.fold("VEE")(_.toString)} for ${tx.transactionType} transaction does not exceed minimal value of $minimumFee"))
         }
       case None =>
         Left(GenericError(s"Minimum fee is not defined for ${TransactionAssetFee(tx.transactionType.id, tx.assetFee._1).key}"))

--- a/src/main/scala/scorex/transaction/PaymentTransaction.scala
+++ b/src/main/scala/scorex/transaction/PaymentTransaction.scala
@@ -39,6 +39,7 @@ case class PaymentTransaction private(sender: PublicKeyAccount,
 
   override lazy val json: JsObject =jsonBase() ++ Json.obj(
     "recipient" -> recipient.stringRepr,
+    "feeScale" -> feeScale,
     "amount" -> amount,
   )
 

--- a/src/main/scala/scorex/transaction/assets/exchange/AssetPair.scala
+++ b/src/main/scala/scorex/transaction/assets/exchange/AssetPair.scala
@@ -12,9 +12,9 @@ import scala.util.{Success, Try}
 case class AssetPair(@ApiModelProperty(dataType = "java.lang.String") amountAsset: Option[AssetId],
                      @ApiModelProperty(dataType = "java.lang.String") priceAsset: Option[AssetId]) {
   @ApiModelProperty(hidden = true)
-  lazy val priceAssetStr: String = priceAsset.map(_.base58).getOrElse(AssetPair.WavesName)
+  lazy val priceAssetStr: String = priceAsset.map(_.base58).getOrElse(AssetPair.VEEName)
   @ApiModelProperty(hidden = true)
-  lazy val amountAssetStr: String = amountAsset.map(_.base58).getOrElse(AssetPair.WavesName)
+  lazy val amountAssetStr: String = amountAsset.map(_.base58).getOrElse(AssetPair.VEEName)
 
   override def toString: String = key
 
@@ -43,10 +43,10 @@ case class AssetPair(@ApiModelProperty(dataType = "java.lang.String") amountAsse
 }
 
 object AssetPair {
-  val WavesName = "WAVES"
+  val VEEName = "VEE"
 
   private def extractAssetId(a: String): Try[Option[AssetId]] = a match {
-    case `WavesName` => Success(None)
+    case `VEEName` => Success(None)
     case other => ByteStr.decodeBase58(other).map(Option(_))
   }
 

--- a/src/test/scala/com/wavesplatform/TransactionGen.scala
+++ b/src/test/scala/com/wavesplatform/TransactionGen.scala
@@ -61,7 +61,7 @@ trait TransactionGen {
   val positiveLongGen: Gen[Long] = Gen.choose(1, Long.MaxValue / 100)
   val positiveIntGen: Gen[Int] = Gen.choose(1, Int.MaxValue / 100)
   val positiveShortGen: Gen[Short] = Gen.choose(1, Short.MaxValue)
-  val smallFeeGen: Gen[Long] = Gen.choose(1, 100000000)
+  val smallFeeGen: Gen[Long] = Gen.choose(1, 10000000000L)
   val feeScaleGen: Gen[Short] = Gen.const(100)
   val slotidGen: Gen[Int] = Gen.choose(0, TestFunctionalitySettings.Enabled.numOfSlots - 1)
 
@@ -183,8 +183,9 @@ trait TransactionGen {
     timestamp: Long <- positiveLongGen
     sender: PrivateKeyAccount <- accountGen
     slotId: Int <- slotidGen
+    feeAmount <- smallFeeGen
     //feeScale: Short <- positiveShortGen //set to 100 in this version
-  } yield ContendSlotsTransaction.create(sender, slotId, MinIssueFee, 100, timestamp).right.get
+  } yield ContendSlotsTransaction.create(sender, slotId, feeAmount * 1000, 100, timestamp).right.get
 
   def contendGeneratorP(sender: PrivateKeyAccount, slotId: Int): Gen[ContendSlotsTransaction] =
     timestampGen.flatMap(ts => contendGeneratorP(ts, sender, slotId))
@@ -198,8 +199,9 @@ trait TransactionGen {
     timestamp: Long <- positiveLongGen
     sender: PrivateKeyAccount <- accountGen
     slotId: Int <- slotidGen
+    feeAmount <- smallFeeGen
     //feeScale: Short <- positiveShortGen //set to 100 in this version
-  } yield  ReleaseSlotsTransaction.create(sender, slotId, MinIssueFee, 100, timestamp).right.get
+  } yield  ReleaseSlotsTransaction.create(sender, slotId, feeAmount, 100, timestamp).right.get
 
   def releaseGeneratorP(sender: PrivateKeyAccount, slotId: Int): Gen[ReleaseSlotsTransaction] =
     timestampGen.flatMap(ts => releaseGeneratorP(ts, sender, slotId))

--- a/src/test/scala/com/wavesplatform/http/PaymentRouteSpec.scala
+++ b/src/test/scala/com/wavesplatform/http/PaymentRouteSpec.scala
@@ -25,7 +25,7 @@ class PaymentRouteSpec extends RouteSpec("/vee/payment")
     forAll(accountGen.label("recipient"), positiveLongGen.label("amount"), smallFeeGen.label("fee"), feeScaleGen.label("feeScale")) {
       case (recipient, amount, fee, feeScale) =>
 
-        val timestamp = System.currentTimeMillis()
+        val timestamp = System.currentTimeMillis * 1000000L
         val time = mock[Time]
         (time.getTimestamp _).expects().returns(timestamp).anyNumberOfTimes()
 
@@ -44,8 +44,8 @@ class PaymentRouteSpec extends RouteSpec("/vee/payment")
           (resp \ "assetId").asOpt[String] shouldEqual None
           (resp \ "feeAsset").asOpt[String] shouldEqual None
           (resp \ "type").as[Int] shouldEqual 2
-          (resp \ "fee").as[Int] shouldEqual fee
-          // (resp \ "feeScale").as[Short] shouldEqual 100
+          (resp \ "fee").as[Long] shouldEqual fee
+          (resp \ "feeScale").as[Short] shouldEqual 100
           (resp \ "amount").as[Long] shouldEqual amount
           (resp \ "timestamp").as[Long] shouldEqual tx.right.get.timestamp
           (resp \ "sender").as[String] shouldEqual sender.address

--- a/src/test/scala/com/wavesplatform/matcher/market/MatcherActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/MatcherActorSpecification.scala
@@ -192,7 +192,7 @@ class MatcherActorSpecification extends TestKit(ActorSystem.apply("MatcherTest2"
       val json = GetMarketsResponse(Array(), Seq(MarketData(pair1, a1Name, waves, now, None, None),
         MarketData(pair2, a1Name, a2Name, now, None, None))).json
 
-      ((json \ "markets") (0) \ "priceAsset").as[String] shouldBe AssetPair.WavesName
+      ((json \ "markets") (0) \ "priceAsset").as[String] shouldBe AssetPair.VEEName
       ((json \ "markets") (0) \ "priceAssetName").as[String] shouldBe waves
       ((json \ "markets") (0) \ "amountAsset").as[String] shouldBe a1.get.base58
       ((json \ "markets") (0) \ "amountAssetName").as[String] shouldBe a1Name

--- a/src/test/scala/com/wavesplatform/matcher/market/OrderHistoryActorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/OrderHistoryActorSpecification.scala
@@ -28,7 +28,7 @@ class OrderHistoryActorSpecification extends TestKit(ActorSystem("MatcherTest"))
   }
 
   val settings: MatcherSettings = matcherSettings.copy(account = MatcherAccount.address)
-  val pair = AssetPair(Some(ByteStr("BTC".getBytes)), Some(ByteStr("WAVES".getBytes)))
+  val pair = AssetPair(Some(ByteStr("BTC".getBytes)), Some(ByteStr("VEE".getBytes)))
   val utxPool: UtxPool = stub[UtxPool]
   val wallet = Wallet(WalletSettings(None, "matcher", Some(WalletSeed)))
   wallet.generateNewAccount()

--- a/src/test/scala/com/wavesplatform/matcher/market/OrderValidatorSpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/market/OrderValidatorSpecification.scala
@@ -61,13 +61,13 @@ class OrderValidatorSpecification extends WordSpec
   val pairWavesBtc = AssetPair(None, Some(wbtc))
 
   "OrderValidator" should {
-    "allows buy WAVES for BTC without balance for order fee" in {
+    "allows buy VEE for BTC without balance for order fee" in {
       validateNewOrderTest(Portfolio(0, LeaseInfo.empty, Map(
         wbtc -> 10 * Constants.UnitsInWave
       ))) shouldBe an[Right[_, _]]
     }
 
-    "does not allow buy WAVES for BTC when assets number is negative" in {
+    "does not allow buy VEE for BTC when assets number is negative" in {
       validateNewOrderTest(Portfolio(0, LeaseInfo.empty, Map(
         wbtc -> -10 * Constants.UnitsInWave
       ))) shouldBe a[Left[_, _]]

--- a/src/test/scala/com/wavesplatform/matcher/model/OrderHistorySpecification.scala
+++ b/src/test/scala/com/wavesplatform/matcher/model/OrderHistorySpecification.scala
@@ -55,7 +55,7 @@ class OrderHistorySpecification extends PropSpec
     oh.ordersByPairAndAddress(pair, ord1.senderPublicKey.address) shouldBe Set(ord1.idStr)
   }
 
-  property("New buy WAVES order added") {
+  property("New buy VEE order added") {
     val pair = AssetPair(None, Some(ByteStr("BTC".getBytes)))
     val ord1 = buy(pair, 0.0008, 10000)
 
@@ -68,7 +68,7 @@ class OrderHistorySpecification extends PropSpec
     oh.ordersByPairAndAddress(pair, ord1.senderPublicKey.address) shouldBe Set(ord1.idStr)
   }
 
-  property("New sell WAVES order added") {
+  property("New sell VEE order added") {
     val pair = AssetPair(None, Some(ByteStr("BTC".getBytes)))
     val ord1 = sell(pair, 0.0008, 10000)
 
@@ -80,7 +80,7 @@ class OrderHistorySpecification extends PropSpec
     oh.ordersByPairAndAddress(pair, ord1.senderPublicKey.address) shouldBe Set(ord1.idStr)
   }
 
-  property("New buy and sell WAVES order  added") {
+  property("New buy and sell VEE order  added") {
     val pk = PrivateKeyAccount("private".getBytes("utf-8"))
     val pair = AssetPair(None, Some(ByteStr("BTC".getBytes)))
     val ord1 = buy(pair, 0.0008, 100000000, Some(pk))
@@ -100,7 +100,7 @@ class OrderHistorySpecification extends PropSpec
     oh.ordersByPairAndAddress(pair, ord1.senderPublicKey.address) shouldBe Set(ord1.idStr, ord2.idStr)
   }
 
-  property("Buy WAVES order filled") {
+  property("Buy VEE order filled") {
     val pair = AssetPair(None, Some(ByteStr("BTC".getBytes)))
     val ord1 = buy(pair, 0.0008, 10000)
     val ord2 = sell(pair, 0.0007, 10000)
@@ -121,7 +121,7 @@ class OrderHistorySpecification extends PropSpec
 
   }
 
-  property("Sell WAVES order - filled, buy order - partial") {
+  property("Sell VEE order - filled, buy order - partial") {
     val pair = AssetPair(None, Some(ByteStr("BTC".getBytes)))
     val ord1 = sell(pair, 0.0008, 100000000)
     val ord2 = buy(pair, 0.00085, 120000000)
@@ -145,7 +145,7 @@ class OrderHistorySpecification extends PropSpec
 
   }
 
-  property("Buy WAVES order - filled with 2 steps, sell order - partial") {
+  property("Buy VEE order - filled with 2 steps, sell order - partial") {
     val pair = AssetPair(None, Some(ByteStr("BTC".getBytes)))
     val ord1 = buy(pair, 0.0008, 100000000, matcherFee = Some(300001L))
     val ord2 = sell(pair, 0.00075, 50000000, matcherFee = Some(300001L))

--- a/src/test/scala/com/wavesplatform/settings/FeesSettingsSpecification.scala
+++ b/src/test/scala/com/wavesplatform/settings/FeesSettingsSpecification.scala
@@ -10,12 +10,12 @@ class FeesSettingsSpecification extends FlatSpec with Matchers {
       """waves {
         |  network.file = "xxx"
         |  fees {
-        |    payment.WAVES = 100000
-        |    issue.WAVES = 100000000
-        |    transfer.WAVES = 100000
-        |    reissue.WAVES = 100000
-        |    burn.WAVES = 100000
-        |    exchange.WAVES = 100000
+        |    payment.VEE = 100000
+        |    issue.VEE = 100000000
+        |    transfer.VEE = 100000
+        |    reissue.VEE = 100000
+        |    burn.VEE = 100000
+        |    exchange.VEE = 100000
         |  }
         |  miner.timeout = 10
         |}
@@ -24,36 +24,36 @@ class FeesSettingsSpecification extends FlatSpec with Matchers {
     val settings = FeesSettings.fromConfig(config)
     settings.fees.size should be(6)
 
-    settings.fees(2) should be(List(FeeSettings("WAVES", 100000)))
-    settings.fees(11) should be(List(FeeSettings("WAVES", 100000000)))
-    settings.fees(12) should be(List(FeeSettings("WAVES", 100000)))
-    settings.fees(13) should be(List(FeeSettings("WAVES", 100000)))
-    settings.fees(14) should be(List(FeeSettings("WAVES", 100000)))
-    settings.fees(15) should be(List(FeeSettings("WAVES", 100000)))
+    settings.fees(2) should be(List(FeeSettings("VEE", 100000)))
+    settings.fees(11) should be(List(FeeSettings("VEE", 100000000)))
+    settings.fees(12) should be(List(FeeSettings("VEE", 100000)))
+    settings.fees(13) should be(List(FeeSettings("VEE", 100000)))
+    settings.fees(14) should be(List(FeeSettings("VEE", 100000)))
+    settings.fees(15) should be(List(FeeSettings("VEE", 100000)))
   }
 
   it should "combine read few fees for one transaction type" in {
     val config = ConfigFactory.parseString(
       """waves.fees {
         |  payment {
-        |    WAVES0 = 0
+        |    VEE0 = 0
         |  }
         |  issue {
-        |    WAVES1 = 111
-        |    WAVES2 = 222
-        |    WAVES3 = 333
+        |    VEE1 = 111
+        |    VEE2 = 222
+        |    VEE3 = 333
         |  }
         |  transfer {
-        |    WAVES4 = 444
+        |    VEE4 = 444
         |  }
         |}
       """.stripMargin).resolve()
 
     val settings = FeesSettings.fromConfig(config)
     settings.fees.size should be(3)
-    settings.fees(2).toSet should equal(Set(FeeSettings("WAVES0", 0)))
-    settings.fees(11).toSet should equal(Set(FeeSettings("WAVES1", 111), FeeSettings("WAVES2", 222), FeeSettings("WAVES3", 333)))
-    settings.fees(12).toSet should equal(Set(FeeSettings("WAVES4", 444)))
+    settings.fees(2).toSet should equal(Set(FeeSettings("VEE0", 0)))
+    settings.fees(11).toSet should equal(Set(FeeSettings("VEE1", 111), FeeSettings("VEE2", 222), FeeSettings("VEE3", 333)))
+    settings.fees(12).toSet should equal(Set(FeeSettings("VEE4", 444)))
   }
 
   it should "allow empty list" in {
@@ -66,30 +66,30 @@ class FeesSettingsSpecification extends FlatSpec with Matchers {
   it should "override values" in {
     val config = ConfigFactory.parseString(
       """waves.fees {
-        |  payment.WAVES1 = 1111
-        |  reissue.WAVES5 = 0
+        |  payment.VEE1 = 1111
+        |  reissue.VEE5 = 0
         |}
       """.stripMargin).withFallback(
       ConfigFactory.parseString(
         """waves.fees {
-          |  payment.WAVES = 100000
-          |  issue.WAVES = 100000000
-          |  transfer.WAVES = 100000
-          |  reissue.WAVES = 100000
-          |  burn.WAVES = 100000
-          |  exchange.WAVES = 100000
+          |  payment.VEE = 100000
+          |  issue.VEE = 100000000
+          |  transfer.VEE = 100000
+          |  reissue.VEE = 100000
+          |  burn.VEE = 100000
+          |  exchange.VEE = 100000
           |}
         """.stripMargin)
     ).resolve()
 
     val settings = FeesSettings.fromConfig(config)
     settings.fees.size should be(6)
-    settings.fees(2).toSet should equal(Set(FeeSettings("WAVES", 100000), FeeSettings("WAVES1", 1111)))
-    settings.fees(13).toSet should equal(Set(FeeSettings("WAVES", 100000), FeeSettings("WAVES5", 0)))
+    settings.fees(2).toSet should equal(Set(FeeSettings("VEE", 100000), FeeSettings("VEE1", 1111)))
+    settings.fees(13).toSet should equal(Set(FeeSettings("VEE", 100000), FeeSettings("VEE5", 0)))
   }
 
   it should "fail on incorrect long values" in {
-    val config = ConfigFactory.parseString("waves.fees.payment.WAVES=N/A").resolve()
+    val config = ConfigFactory.parseString("waves.fees.payment.VEE=N/A").resolve()
 
     intercept[BadValue] {
       FeesSettings.fromConfig(config)
@@ -97,7 +97,7 @@ class FeesSettingsSpecification extends FlatSpec with Matchers {
   }
 
   it should "fail on unknown transaction type" in {
-    val config = ConfigFactory.parseString("waves.fees.shmayment.WAVES=100").resolve()
+    val config = ConfigFactory.parseString("waves.fees.shmayment.VEE=100").resolve()
 
     intercept[NoSuchElementException] {
       FeesSettings.fromConfig(config)
@@ -110,71 +110,71 @@ class FeesSettingsSpecification extends FlatSpec with Matchers {
       """
         |waves.fees {
         |  payment {
-        |    WAVES = 10000000
+        |    VEE = 10000000
         |  }
         |  issue {
-        |    WAVES = 100000000
+        |    VEE = 100000000
         |  }
         |  transfer {
-        |    WAVES = 10000000,
+        |    VEE = 10000000,
         |    "6MPKrD5B7GrfbciHECg1MwdvRUhRETApgNZspreBJ8JL" = 1
         |  }
         |  reissue {
-        |    WAVES = 10000000
+        |    VEE = 10000000
         |  }
         |  burn {
-        |    WAVES = 10000000
+        |    VEE = 10000000
         |  }
         |  exchange {
-        |    WAVES = 10000000
+        |    VEE = 10000000
         |  }
         |  lease {
-        |    WAVES = 10000000
+        |    VEE = 10000000
         |  }
         |  lease-cancel {
-        |    WAVES = 10000000
+        |    VEE = 10000000
         |  }
         |  create-alias {
-        |    WAVES = 10000000
+        |    VEE = 10000000
         |  }
         |  contend-slots {
-        |    WAVES = 100000000000
+        |    VEE = 100000000000
         |  }
         |  release-slots {
-        |    WAVES = 10000000
+        |    VEE = 10000000
         |  }
         |  minting {
-        |    WAVES = 100000
+        |    VEE = 100000
         |  }
         |  create-contract{
-        |    WAVES = 20000000
+        |    VEE = 20000000
         |  }
         |  change-contract-status{
-        |    WAVES = 10000000
+        |    VEE = 10000000
         |  }
         |  db-put{
-        |    WAVES = 100000000
+        |    VEE = 100000000
         |  }
         |}
       """.stripMargin).withFallback(defaultConfig).resolve()
     val settings = FeesSettings.fromConfig(config)
     settings.fees.size should be(15)
 
-    settings.fees(2).toSet should equal(Set(FeeSettings("WAVES", 10000000)))
-    settings.fees(3).toSet should equal(Set(FeeSettings("WAVES", 10000000)))
-    settings.fees(4).toSet should equal(Set(FeeSettings("WAVES", 10000000)))
-    settings.fees(5).toSet should equal(Set(FeeSettings("WAVES", 100000)))
-    settings.fees(6).toSet should equal(Set(FeeSettings("WAVES", 100000000000L)))
-    settings.fees(7).toSet should equal(Set(FeeSettings("WAVES", 10000000)))
-    settings.fees(8).toSet should equal(Set(FeeSettings("WAVES", 20000000)))
-    settings.fees(9).toSet should equal(Set(FeeSettings("WAVES", 10000000)))
-    settings.fees(10).toSet should equal(Set(FeeSettings("WAVES", 100000000)))
-    settings.fees(11).toSet should equal(Set(FeeSettings("WAVES", 100000000)))
-    settings.fees(12).toSet should equal(Set(FeeSettings("WAVES", 10000000), FeeSettings("6MPKrD5B7GrfbciHECg1MwdvRUhRETApgNZspreBJ8JL", 1)))
-    settings.fees(13).toSet should equal(Set(FeeSettings("WAVES", 10000000)))
-    settings.fees(14).toSet should equal(Set(FeeSettings("WAVES", 10000000)))
-    settings.fees(15).toSet should equal(Set(FeeSettings("WAVES", 10000000)))
-    settings.fees(16).toSet should equal(Set(FeeSettings("WAVES", 10000000)))
+    settings.fees(2).toSet should equal(Set(FeeSettings("VEE", 10000000)))
+    settings.fees(3).toSet should equal(Set(FeeSettings("VEE", 10000000)))
+    settings.fees(4).toSet should equal(Set(FeeSettings("VEE", 10000000)))
+    settings.fees(5).toSet should equal(Set(FeeSettings("VEE", 100000)))
+    settings.fees(6).toSet should equal(Set(FeeSettings("VEE", 100000000000L)))
+    settings.fees(7).toSet should equal(Set(FeeSettings("VEE", 10000000)))
+    settings.fees(8).toSet should equal(Set(FeeSettings("VEE", 20000000)))
+    settings.fees(9).toSet should equal(Set(FeeSettings("VEE", 10000000)))
+    settings.fees(10).toSet should equal(Set(FeeSettings("VEE", 100000000)))
+    settings.fees(11).toSet should equal(Set(FeeSettings("VEE", 100000000)))
+    settings.fees(12).toSet should equal(Set(FeeSettings("VEE", 10000000), FeeSettings("6MPKrD5B7GrfbciHECg1MwdvRUhRETApgNZspreBJ8JL", 1)))
+    settings.fees(13).toSet should equal(Set(FeeSettings("VEE", 10000000)))
+    settings.fees(14).toSet should equal(Set(FeeSettings("VEE", 10000000)))
+    settings.fees(15).toSet should equal(Set(FeeSettings("VEE", 10000000)))
+    settings.fees(16).toSet should equal(Set(FeeSettings("VEE", 10000000)))
 
   }
 }

--- a/src/test/scala/com/wavesplatform/state2/diffs/AssetTransactionsDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/AssetTransactionsDiffTest.scala
@@ -26,7 +26,7 @@ class AssetTransactionsDiffTest extends PropSpec with PropertyChecks with Genera
   } yield ((genesis, issue), (reissue, burn))
 
 
-  property("Issue+Reissue+Burn do not break waves invariant and updates state") {
+  property("Issue+Reissue+Burn do not break vee invariant and updates state") {
     forAll(issueReissueBurnTxs(isReissuable = true)) { case (((gen, issue), (reissue, burn))) =>
       assertDiffAndState(Seq(TestBlock.create(Seq(gen, issue))), TestBlock.create(Seq(reissue, burn))) { case (blockDiff, newState) =>
         val totalPortfolioDiff = Monoid.combineAll(blockDiff.txsDiff.portfolios.values)

--- a/src/test/scala/com/wavesplatform/state2/diffs/BalanceDiffValidationTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/BalanceDiffValidationTest.scala
@@ -31,7 +31,7 @@ class BalanceDiffValidationTest extends PropSpec with PropertyChecks with Genera
 
     forAll(preconditionsAndPayment) { case ((gen1, gen2, transfer1, transfer2)) =>
       assertDiffEi(Seq(TestBlock.create(Seq(gen1, gen2, transfer1))), TestBlock.create(Seq(transfer2))) { blockDiffEi =>
-        blockDiffEi should produce("negative waves balance")
+        blockDiffEi should produce("negative vee balance")
       }
     }
   }

--- a/src/test/scala/com/wavesplatform/state2/diffs/CreateAliasTransactionDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/CreateAliasTransactionDiffTest.scala
@@ -30,7 +30,7 @@ class CreateAliasTransactionDiffTest extends PropSpec with PropertyChecks with G
     anotherAliasTx = CreateAliasTransaction.create(master, alias2, fee + 3, ts).right.get
   } yield (genesis, aliasTx, sameAliasTx, sameAliasOtherSenderTx, anotherAliasTx)
 
-  property("can create and resolve aliases preserving waves invariant") {
+  property("can create and resolve aliases preserving vee invariant") {
     forAll(preconditionsAndAliasCreations) { case (gen, aliasTx, _, _, anotherAliasTx) =>
       assertDiffAndState(Seq(TestBlock.create(Seq(gen, aliasTx))), TestBlock.create(Seq(anotherAliasTx))) { case (blockDiff, newState) =>
         val totalPortfolioDiff = Monoid.combineAll(blockDiff.txsDiff.portfolios.values)

--- a/src/test/scala/com/wavesplatform/state2/diffs/ExchangeTransactionDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/ExchangeTransactionDiffTest.scala
@@ -25,7 +25,7 @@ class ExchangeTransactionDiffTest extends PropSpec with PropertyChecks with Gene
 
   private implicit def noShrink[A]: Shrink[A] = Shrink(_ => Stream.empty)
 
-  property("preserves waves invariant, stores match info, rewards matcher") {
+  property("preserves vee invariant, stores match info, rewards matcher") {
 
     val preconditionsAndExchange: Gen[(GenesisTransaction, GenesisTransaction, IssueTransaction, IssueTransaction, ExchangeTransaction)] = for {
       buyer <- accountGen
@@ -52,7 +52,7 @@ class ExchangeTransactionDiffTest extends PropSpec with PropertyChecks with Gene
     }
   }
 
-  property("buy waves without enough money for fee") {
+  property("buy vee without enough money for fee") {
     val preconditions: Gen[(GenesisTransaction, GenesisTransaction, IssueTransaction, ExchangeTransaction)] = for {
       buyer <- accountGen
       seller <- accountGen

--- a/src/test/scala/com/wavesplatform/state2/diffs/GenesisTransactionDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/GenesisTransactionDiffTest.scala
@@ -20,7 +20,7 @@ class GenesisTransactionDiffTest extends PropSpec with PropertyChecks with Gener
     }
   }
 
-  property("Diff establishes Waves invariant") {
+  property("Diff establishes VEE invariant") {
     forAll(nelMax(genesisGen)) { gtxs =>
       assertDiffAndState(Seq.empty, TestBlock.create(gtxs)) { (blockDiff, state) =>
         val totalPortfolioDiff: Portfolio = Monoid.combineAll(blockDiff.txsDiff.portfolios.values)

--- a/src/test/scala/com/wavesplatform/state2/diffs/LeaseTransactionsDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/LeaseTransactionsDiffTest.scala
@@ -23,7 +23,7 @@ class LeaseTransactionsDiffTest extends PropSpec with PropertyChecks with Genera
 
   def total(l: LeaseInfo): Long = l.leaseIn - l.leaseOut
 
-  property("can lease/cancel lease preserving waves invariant") {
+  property("can lease/cancel lease preserving vee invariant") {
 
     val sunnyDayLeaseLeaseCancel: Gen[(GenesisTransaction, LeaseTransaction, LeaseCancelTransaction, Long, Long)] = for {
       master <- accountGen

--- a/src/test/scala/com/wavesplatform/state2/diffs/TransferTransactionDiffTest.scala
+++ b/src/test/scala/com/wavesplatform/state2/diffs/TransferTransactionDiffTest.scala
@@ -29,7 +29,7 @@ class TransferTransactionDiffTest extends PropSpec with PropertyChecks with Gene
     transfer <- transferGeneratorP(master, recepient, maybeAsset.map(_.id), maybeFeeAsset.map(_.id))
   } yield (genesis, issue1, issue2, transfer)
 
-  property("transfers assets to recipient preserving waves invariant") {
+  property("transfers assets to recipient preserving vee invariant") {
     forAll(preconditionsAndTransfer) { case ((genesis, issue1, issue2, transfer)) =>
       assertDiffAndState(Seq(TestBlock.create(Seq(genesis, issue1, issue2))), TestBlock.create(Seq(transfer))) { case (totalDiff, newState) =>
         val totalPortfolioDiff = Monoid.combineAll(totalDiff.txsDiff.portfolios.values)

--- a/src/test/scala/scorex/transaction/FeeCalculatorSpecification.scala
+++ b/src/test/scala/scorex/transaction/FeeCalculatorSpecification.scala
@@ -9,6 +9,7 @@ import org.scalatest.{Assertion, Matchers, PropSpec}
 import scorex.account.{Address, PrivateKeyAccount}
 import scorex.transaction.assets._
 import scorex.transaction.lease.{LeaseCancelTransaction, LeaseTransaction}
+import vee.transaction.spos.{ContendSlotsTransaction, ReleaseSlotsTransaction}
 
 
 class FeeCalculatorSpecification extends PropSpec with PropertyChecks with GeneratorDrivenPropertyChecks
@@ -19,29 +20,35 @@ class FeeCalculatorSpecification extends PropSpec with PropertyChecks with Gener
     """waves {
       |  fees {
       |    payment {
-      |      WAVES = 100000
+      |      VEE = 10000000
       |    }
       |    issue {
-      |      WAVES = 100000000
+      |      VEE = 100000000
       |    }
       |    transfer {
-      |      WAVES = 100000
+      |      VEE = 10000000
       |      "JAudr64y6YxTgLn9T5giKKqWGkbMfzhdRAxmNNfn6FJN" = 2
       |    }
       |    reissue {
-      |      WAVES = 200000
+      |      VEE = 10000000
       |    }
       |    burn {
-      |      WAVES = 300000
+      |      VEE = 10000000
       |    }
       |    lease {
-      |      WAVES = 400000
+      |      VEE = 10000000
       |    }
       |    lease-cancel {
-      |      WAVES = 500000
+      |      VEE = 10000000
       |    }
       |    create-alias {
-      |      WAVES = 600000
+      |      VEE = 10000000
+      |    }
+      |    contend-slots {
+      |      VEE = 100000000000
+      |    }
+      |    release-slots {
+      |      VEE = 10000000
       |    }
       |  }
       |}""".stripMargin
@@ -67,7 +74,7 @@ class FeeCalculatorSpecification extends PropSpec with PropertyChecks with Gener
     val feeCalc = new FeeCalculator(mySettings)
     forAll(transferGen) { tx: TransferTransaction =>
       if (tx.feeAssetId.isEmpty) {
-        feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 100000)
+        feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 10000000)
       } else {
         feeCalc.enoughFee(tx) shouldBe an[Left[_,_]]
       }
@@ -90,7 +97,7 @@ class FeeCalculatorSpecification extends PropSpec with PropertyChecks with Gener
   property("Payment transaction ") {
     val feeCalc = new FeeCalculator(mySettings)
     forAll(paymentGen) { tx: PaymentTransaction =>
-      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 100000)
+      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 10000000)
     }
   }
 
@@ -104,35 +111,49 @@ class FeeCalculatorSpecification extends PropSpec with PropertyChecks with Gener
   property("Reissue transaction ") {
     val feeCalc = new FeeCalculator(mySettings)
     forAll(reissueGen) { tx: ReissueTransaction =>
-      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 200000)
+      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 10000000)
     }
   }
 
   property("Burn transaction ") {
     val feeCalc = new FeeCalculator(mySettings)
     forAll(burnGen) { tx: BurnTransaction =>
-      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 300000)
+      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 10000000)
     }
   }
 
   property("Lease transaction") {
     val feeCalc = new FeeCalculator(mySettings)
     forAll(leaseGen) { tx: LeaseTransaction =>
-      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 400000)
+      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 10000000)
     }
   }
 
   property("Lease cancel transaction") {
     val feeCalc = new FeeCalculator(mySettings)
     forAll(leaseCancelGen) { tx: LeaseCancelTransaction =>
-      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 500000)
+      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 10000000)
     }
   }
 
   property("Create alias transaction") {
     val feeCalc = new FeeCalculator(mySettings)
     forAll(createAliasGen) { tx: CreateAliasTransaction =>
-      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 600000)
+      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 10000000)
+    }
+  }
+
+  property("Contend slots transaction") {
+    val feeCalc = new FeeCalculator(mySettings)
+    forAll(contendSlotsGen) { tx: ContendSlotsTransaction =>
+      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 100000000000L)
+    }
+  }
+
+  property("Release slots transaction") {
+    val feeCalc = new FeeCalculator(mySettings)
+    forAll(releaseSlotsGen) { tx: ReleaseSlotsTransaction =>
+      feeCalc.enoughFee(tx) shouldBeRightIf (tx.fee >= 10000000)
     }
   }
 


### PR DESCRIPTION
1. change the default fee asset id to VEE
2. change some log and test log output from WAVES to VEE
3. add feeScale into Payment transaction Json, and add the feeScale check in unit test. this is issue fix for https://github.com/excelsia/VEE/pull/72
4. add contend/release fee calculator test
5. change some simple used variable/class name to VEE format

unit test passed
```scala
[info] ScalaTest
[info] Run completed in 1 minute, 8 seconds.
[info] Total number of tests run: 285
[info] Suites: completed 88, aborted 0
[info] Tests: succeeded 285, failed 0, canceled 0, ignored 14, pending 2
[info] All tests passed.
[info] Passed: Total 285, Failed 0, Errors 0, Passed 285, Ignored 14, Pending 2
[success] Total time: 87 s, completed Aug 13, 2018 11:19:06 AM
```
manually start the node (stopped at height 40), tested the api error for InsufficientFee case:
orginal:
```
{
  "error": 199,
  "message": "Fee in WAVES for PaymentTransaction transaction does not exceed minimal value of 10000000"
}
```
now:
```
{
  "error": 199,
  "message": "Fee in VEE for PaymentTransaction transaction does not exceed minimal value of 10000000"
}
```