### PR TITLE
add utf8 validation for dbput transaction, following https://tech.zil…

### DIFF
--- a/src/main/scala/scorex/api/http/ApiError.scala
+++ b/src/main/scala/scorex/api/http/ApiError.scala
@@ -43,6 +43,7 @@ object ApiError {
     case ValidationError.DbDataTypeError(err) => InvalidDbDataType(err)
     case ValidationError.WrongFeeScale(errFeeScale) => InvalidFeeScale(errFeeScale)
     case ValidationError.TooLongDbEntry(actualLength, maxLength) => TooLongDbEntry(actualLength, maxLength)
+    case ValidationError.InvalidUTF8String(field) => InvalidUTF8String(field)
     case TransactionValidationError(error, tx) => error match {
       case ValidationError.Mistiming(errorMessage) => Mistiming(errorMessage)
       case _ => StateCheckFailed(tx, fromValidationError(error).message)
@@ -186,6 +187,12 @@ case object InvalidDbKey extends ApiError {
   override val id: Int = 117
   override val message: String = "invalid db key"
   override val code: StatusCode = StatusCodes.BadRequest
+}
+
+case class InvalidUTF8String(field: String) extends ApiError {
+  override val id: Int = 118
+  override val code = StatusCodes.BadRequest
+  override val message: String = s"The $field is not a valid utf8 string"
 }
 
 case class CustomValidationError(errorMessage: String) extends ApiError {

--- a/src/main/scala/scorex/serialization/Deser.scala
+++ b/src/main/scala/scorex/serialization/Deser.scala
@@ -1,5 +1,8 @@
 package scorex.serialization
 
+import java.nio.{ByteBuffer, CharBuffer}
+import java.nio.charset.{Charset, CharsetDecoder, CharsetEncoder}
+
 import com.google.common.primitives.{Bytes, Shorts}
 
 object Deser {
@@ -30,4 +33,19 @@ object Deser {
     r._1
   }
 
+  val encoder = ThreadLocal.withInitial[CharsetEncoder](() => Charset.forName("UTF-8").newEncoder);
+  def decoder = ThreadLocal.withInitial[CharsetDecoder](() => Charset.forName("UTF-8").newDecoder);
+
+  def validUTF8(string: String): Boolean = {
+    encoder.get().canEncode(string)
+  }
+
+  def serilizeString(string: String) : Array[Byte] = {
+    val bytes: ByteBuffer = encoder.get().encode(CharBuffer.wrap(string))
+    bytes.array.slice(bytes.position, bytes.limit)
+  }
+
+  def deserilizeString(bytes: Array[Byte]) :String = {
+    decoder.get().decode(ByteBuffer.wrap(bytes)).toString
+  }
 }

--- a/src/main/scala/scorex/transaction/TransactionFactory.scala
+++ b/src/main/scala/scorex/transaction/TransactionFactory.scala
@@ -18,8 +18,6 @@ import vee.transaction.database.DbPutTransaction
 import scorex.transaction.lease.{LeaseCancelTransaction, LeaseTransaction}
 import scorex.utils.Time
 import vee.wallet.Wallet
-import vee.database.{DataType, Entry}
-import scorex.transaction.ValidationError.DbDataTypeError
 
 object TransactionFactory {
 
@@ -109,12 +107,7 @@ object TransactionFactory {
 
   def dbPut(request: DbPutRequest, wallet: Wallet, time: Time): Either[ValidationError, DbPutTransaction] = for {
     senderPrivateKey <- wallet.findPrivateKey(request.sender)
-    datatype <- DataType.values.find(_.toString == request.dataType) match {
-      case Some(x) => Right(x)
-      case None =>Left(DbDataTypeError(request.dataType))
-    }
-    dbEntry <- Entry.buildEntry(request.data, datatype)
-    tx <- DbPutTransaction.create(senderPrivateKey, request.dbKey, dbEntry, request.fee, request.feeScale, time.getTimestamp())
+    tx <- DbPutTransaction.create(senderPrivateKey, request.dbKey, request.dataType, request.data, request.fee, request.feeScale, time.getTimestamp())
   } yield tx
 
   def reissueAsset(request: ReissueRequest, wallet: Wallet, time: Time): Either[ValidationError, ReissueTransaction] = for {

--- a/src/main/scala/scorex/transaction/ValidationError.scala
+++ b/src/main/scala/scorex/transaction/ValidationError.scala
@@ -11,6 +11,7 @@ object ValidationError {
   case object InvalidDataType extends ValidationError
   case object InvalidDataLength extends ValidationError
   case class TooLongDbEntry(actualLength: Int, maxLength: Int) extends ValidationError
+  case class InvalidUTF8String(field: String) extends ValidationError
   case object InvalidDataEntry extends ValidationError
   case object InvalidProofType extends ValidationError
   case object InvalidProofLength extends ValidationError

--- a/src/main/scala/vee/api/http/database/SignedDbPutRequest.scala
+++ b/src/main/scala/vee/api/http/database/SignedDbPutRequest.scala
@@ -6,8 +6,6 @@ import scorex.account.PublicKeyAccount
 import scorex.api.http.BroadcastRequest
 import scorex.transaction.TransactionParser.SignatureStringLength
 import scorex.transaction.ValidationError
-import scorex.transaction.ValidationError.DbDataTypeError
-import vee.database.{DataType, Entry}
 import vee.transaction.database.DbPutTransaction
 
 case class SignedDbPutRequest(@ApiModelProperty(value = "Base58 encoded sender public key", required = true)
@@ -29,12 +27,7 @@ case class SignedDbPutRequest(@ApiModelProperty(value = "Base58 encoded sender p
   def toTx: Either[ValidationError, DbPutTransaction] = for {
     _sender <- PublicKeyAccount.fromBase58String(senderPublicKey)
     _signature <- parseBase58(signature, "invalid.signature", SignatureStringLength)
-    _dataType <- DataType.values.find(_.toString == dataType) match {
-      case Some(x) => Right(x)
-      case None =>Left(DbDataTypeError(dataType))
-    }
-    dbEntry <- Entry.buildEntry(data, _dataType)
-    _t <- DbPutTransaction.create(_sender, dbKey, dbEntry, fee, feeScale, timestamp, _signature)
+    _t <- DbPutTransaction.create(_sender, dbKey, dataType, data, fee, feeScale, timestamp, _signature)
   } yield _t
 }
 

--- a/src/test/scala/com/wavesplatform/TransactionGen.scala
+++ b/src/test/scala/com/wavesplatform/TransactionGen.scala
@@ -41,6 +41,8 @@ trait TransactionGen {
 
   val aliasSymbolChar: Gen[Char] = Gen.oneOf('.','@', '_', '-')
 
+  val invalidUtf8Char: Gen[Char] = Gen.oneOf('\uD800','\uD801', '\uD802')
+
   val aliasAlphabetGen: Gen[Char] = frequency((1, numChar), (1, aliasSymbolChar), (9, alphaLowerChar))
 
   val invalidAliasAlphabetGen: Gen[Char] = frequency((1, numChar), (1, aliasSymbolChar), (9, alphaUpperChar))
@@ -89,6 +91,10 @@ trait TransactionGen {
   val entryGen: Gen[Entry] = for {
     data: String <- entryDataStringGen
   } yield Entry.buildEntry(data, DataType.ByteArray).right.get
+
+  val invalidUtf8StringGen: Gen[String] = for {
+    data <- Gen.listOfN(2, invalidUtf8Char)
+  } yield data.mkString
 
   val contractContentGen: Gen[String] = for {
     length <- Gen.chooseNum(Alias.MinLength, Alias.MaxLength)


### PR DESCRIPTION
add based on https://tech.zilverline.com/2011/04/07/serializing-strings-using-scalacheck

also move the logic to build dbEntry to dbPutTransaction

still not very clear if those validation are enough. if all agreed, I will add the validation to other transactions if needed.

not very sure if the multi-threading is needed.