### PR TITLE
Replace network p2p message start magic number

### DIFF
--- a/src/main/scala/com/wavesplatform/network/LegacyFrameCodec.scala
+++ b/src/main/scala/com/wavesplatform/network/LegacyFrameCodec.scala
@@ -58,7 +58,7 @@ class LegacyFrameCodec(peerDatabase: PeerDatabase) extends ByteToMessageCodec[Ra
 }
 
 object LegacyFrameCodec {
-  val Magic = 0x12345678
+  val Magic = 0xbfadafbe
 
   private val messageSpecs: Map[Byte, MessageSpec[_ <: AnyRef]] =
     BasicMessagesRepo.specs.map(s => s.messageCode -> s).toMap


### PR DESCRIPTION
(Bitcoin convention)
The message start string is designed to be unlikely to occur in normal data. The characters are rarely used upper ASCII, not valid as UTF-8, and produce a large 4-byte int at any alignment.

Passed unit tests and manual node startup.