### PR TITLE
add contract and payment API request tests

### DIFF
--- a/src/test/scala/vee/transaction/api/http/contract/ContractRequestsTests.scala
+++ b/src/test/scala/vee/transaction/api/http/contract/ContractRequestsTests.scala
@@ -1,0 +1,81 @@
+package vee.transaction.api.http.contract
+
+import org.scalatest.{FunSuite, Matchers}
+import play.api.libs.json.Json
+import vee.api.http.contract
+import vee.api.http.contract.{ChangeContractStatusRequest, CreateContractRequest, SignedChangeContractStatusRequest, SignedCreateContractRequest}
+
+class ContractRequestsTests extends FunSuite with Matchers {
+
+  test("CreateContractRequest") {
+    val json =
+      """
+        {
+          "sender": "3MwKzMxUKaDaS4CXM8KNowCJJUnTSHDFGMb",
+          "fee": 20000000,
+          "feeScale": 100,
+          "name": "test",
+          "content": "vee test content"
+        }
+      """
+
+    val req = Json.parse(json).validate[CreateContractRequest].get
+
+    req shouldBe contract.CreateContractRequest("3MwKzMxUKaDaS4CXM8KNowCJJUnTSHDFGMb", "test", "vee test content", 20000000L, 100)
+  }
+
+  test("ChangeContractStatusRequest") {
+    val json =
+      """
+        {
+          "sender": "3Myss6gmMckKYtka3cKCM563TBJofnxvfD7",
+          "fee": 10000000,
+          "feeScale": 100,
+          "contractName": "test"
+        }
+      """
+
+    val req = Json.parse(json).validate[ChangeContractStatusRequest].get
+
+    req shouldBe contract.ChangeContractStatusRequest("3Myss6gmMckKYtka3cKCM563TBJofnxvfD7", "test", 10000000L, 100)
+  }
+
+  test("SignedCreateContractRequest") {
+    val json =
+      """
+        {
+         "senderPublicKey":"CRxqEuxhdZBEHX42MU4FfyJxuHmbDBTaHMhM3Uki7pLw",
+         "fee": 20000000,
+         "feeScale": 100,
+         "name": "test",
+         "content": "vee test content",
+         "timestamp":0,
+         "signature":"4VPg4piLZGQz3vBqCPbjTfAR4cDErMi57rDvyith5XrQJDLryU2w2JsL3p4ejEqTPpctZ5YekpQwZPTtYiGo5yPC"
+         }
+      """
+
+    val req = Json.parse(json).validate[SignedCreateContractRequest].get
+
+    req shouldBe contract.SignedCreateContractRequest("CRxqEuxhdZBEHX42MU4FfyJxuHmbDBTaHMhM3Uki7pLw", 20000000L,
+      100, "test", "vee test content", 0L, "4VPg4piLZGQz3vBqCPbjTfAR4cDErMi57rDvyith5XrQJDLryU2w2JsL3p4ejEqTPpctZ5YekpQwZPTtYiGo5yPC")
+  }
+
+  test("SignedChangeContractStatusRequest") {
+    val json =
+      """
+        {
+         "senderPublicKey":"CRxqEuxhdZBEHX42MU4FfyJxuHmbDBTaHMhM3Uki7pLw",
+         "fee": 10000000,
+         "feeScale": 100,
+         "contractName": "test",
+         "timestamp":0,
+         "signature":"4VPg4piLZGQz3vBqCPbjTfAR4cDErMi57rDvyith5XrQJDLryU2w2JsL3p4ejEqTPpctZ5YekpQwZPTtYiGo5yPC"
+         }
+      """
+
+    val req = Json.parse(json).validate[SignedChangeContractStatusRequest].get
+
+    req shouldBe contract.SignedChangeContractStatusRequest("CRxqEuxhdZBEHX42MU4FfyJxuHmbDBTaHMhM3Uki7pLw", "test",
+      10000000L, 100, 0L, "4VPg4piLZGQz3vBqCPbjTfAR4cDErMi57rDvyith5XrQJDLryU2w2JsL3p4ejEqTPpctZ5YekpQwZPTtYiGo5yPC")
+  }
+}

--- a/src/test/scala/vee/transaction/api/http/payment/PaymentRequestsTests.scala
+++ b/src/test/scala/vee/transaction/api/http/payment/PaymentRequestsTests.scala
@@ -1,0 +1,49 @@
+package vee.transaction.api.http.payment
+
+import org.scalatest.{FunSuite, Matchers}
+import play.api.libs.json.Json
+import vee.api.http.vee.SignedPaymentRequest
+import scorex.api.http.assets.PaymentRequest
+
+class PaymentRequestsTests extends FunSuite with Matchers {
+
+  test("PaymentRequest") {
+    val json =
+      """
+        {
+          "sender": "3MwKzMxUKaDaS4CXM8KNowCJJUnTSHDFGMb",
+          "fee": 10000000,
+          "feeScale": 100,
+          "recipient": "ATuYeyAT3HBkMQkbZRoyjR75Ajxd1ppWBYV",
+          "amount": 100000000000000,
+          "attachment": "v"
+        }
+      """
+
+    val req = Json.parse(json).validate[PaymentRequest].get
+
+    req shouldBe PaymentRequest(100000000000000L, 10000000L, 100, "3MwKzMxUKaDaS4CXM8KNowCJJUnTSHDFGMb", Option("v"), "ATuYeyAT3HBkMQkbZRoyjR75Ajxd1ppWBYV")
+  }
+
+  test("SignedPaymentRequest") {
+    val json =
+      """
+        {
+         "senderPublicKey":"CRxqEuxhdZBEHX42MU4FfyJxuHmbDBTaHMhM3Uki7pLw",
+         "fee": 10000000,
+         "feeScale": 100,
+         "recipient": "ATuYeyAT3HBkMQkbZRoyjR75Ajxd1ppWBYV",
+         "amount": 100000000000000,
+         "attachment": "v",
+         "timestamp":0,
+         "signature":"4VPg4piLZGQz3vBqCPbjTfAR4cDErMi57rDvyith5XrQJDLryU2w2JsL3p4ejEqTPpctZ5YekpQwZPTtYiGo5yPC"
+         }
+      """
+
+    val req = Json.parse(json).validate[SignedPaymentRequest].get
+
+    req shouldBe SignedPaymentRequest(0L, 100000000000000L, 10000000L, 100, "ATuYeyAT3HBkMQkbZRoyjR75Ajxd1ppWBYV",
+      "CRxqEuxhdZBEHX42MU4FfyJxuHmbDBTaHMhM3Uki7pLw", Option("v"), "4VPg4piLZGQz3vBqCPbjTfAR4cDErMi57rDvyith5XrQJDLryU2w2JsL3p4ejEqTPpctZ5YekpQwZPTtYiGo5yPC")
+  }
+
+}


### PR DESCRIPTION
1. add contract  API request tests
2. add payment API request tests

unit test passed
```scala
[info] ScalaTest
[info] Run completed in 1 minute, 30 seconds.
[info] Total number of tests run: 325
[info] Suites: completed 101, aborted 0
[info] Tests: succeeded 325, failed 0, canceled 0, ignored 14, pending 2
[info] All tests passed.
[info] Passed: Total 325, Failed 0, Errors 0, Passed 325, Ignored 14, Pending 2
[success] Total time: 98 s, completed Aug 23, 2018 12:03:28 PM
```